### PR TITLE
backend/irc: prefix '{nick}: ' for messages directed at requester

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include COPYING
 include *.rst
 include errbot/builtins/*.plug
 include errbot/*.svg

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -1149,9 +1149,20 @@ class Backend(object):
         bottom = self.bottom_of_help_message()
         return ''.join(filter(None, [top, description, usage, bottom]))
 
-    def send(self, user, text, in_reply_to=None, message_type='chat'):
+    def send(self, user, text, in_reply_to=None, message_type='chat', groupchat_nick_reply=False):
         """Sends a simple message to the specified user."""
-        mess = self.build_message(text)
+
+        nick_reply = self.bot_config.GROUPCHAT_NICK_PREFIXED
+
+        if (message_type == 'groupchat'
+                and in_reply_to
+                and nick_reply
+                and groupchat_nick_reply):
+            reply_text = self.groupchat_reply_format().format(in_reply_to.nick, text)
+        else:
+            reply_text = text
+
+        mess = self.build_message(reply_text)
         if hasattr(user, 'stripped'):
             mess.to = user.stripped
         else:
@@ -1167,6 +1178,9 @@ class Backend(object):
         self.send_message(mess)
 
     # ##### HERE ARE THE SPECIFICS TO IMPLEMENT PER BACKEND
+
+    def groupchat_reply_format(self):
+        raise NotImplementedError("It should be implemented specifically for your backend")
 
     def build_message(self, text):
         raise NotImplementedError("It should be implemented specifically for your backend")

--- a/errbot/backends/campfire.py
+++ b/errbot/backends/campfire.py
@@ -120,3 +120,6 @@ class CampfireBackend(ErrBot):
     @property
     def mode(self):
         return 'campfire'
+
+    def groupchat_reply_format(self):
+        return '@{0} {1}'

--- a/errbot/backends/graphic.py
+++ b/errbot/backends/graphic.py
@@ -244,3 +244,6 @@ class GraphicBackend(TextBackend):
     @property
     def mode(self):
         return 'graphic'
+
+    def groupchat_reply_format(self):
+        return '{0} {1}'

--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -362,3 +362,6 @@ class HipchatBackend(XMPPBackend):
             name = room
 
         return HipChatMUCRoom(name)
+
+    def groupchat_reply_format(self):
+        return '@{0} {1}'

--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -305,8 +305,8 @@ class IRCBackend(ErrBot):
 
         if in_reply_to and message_type == 'groupchat' and nick_reply:
             super().send(user,
-                        '{}: {}'.format(in_reply_to.nick, text),
-                        in_reply_to,
-                        message_type)
+                         '{}: {}'.format(in_reply_to.nick, text),
+                         in_reply_to,
+                         message_type)
         else:
             super().send(user, text, in_reply_to, message_type)

--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -301,18 +301,12 @@ class IRCBackend(ErrBot):
     def send(self, user, text, in_reply_to=None, message_type='chat'):
         """Sends a simple message to the specified user."""
 
-        if in_reply_to:
-            if message_type == 'groupchat':
-                text = '{0}: {1}'.format(in_reply_to, text)
+        nick_reply = config.__dict__.get('IRC_NICK_PREFIX_REPLY', False)
 
-        mess = self.build_message(text)
-
-        if hasattr(user, 'stripped'):
-            mess.to = user.stripped
+        if in_reply_to and message_type == 'groupchat' and nick_reply:
+            super().send(user,
+                        '{}: {}'.format(in_reply_to.nick, text),
+                        in_reply_to,
+                        message_type)
         else:
-            mess.to = user
-
-        mess.type = message_type
-        mess.frm = mess.to
-
-        self.send_message(mess)
+            super().send(user, text, in_reply_to, message_type)

--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -297,3 +297,22 @@ class IRCBackend(ErrBot):
 
         channels = self.conn.channels.keys()
         return [IRCMUCRoom(node=channel) for channel in channels]
+
+    def send(self, user, text, in_reply_to=None, message_type='chat'):
+        """Sends a simple message to the specified user."""
+
+        if in_reply_to:
+            if message_type == 'groupchat':
+                text = '{0}: {1}'.format(in_reply_to, text)
+
+        mess = self.build_message(text)
+
+        if hasattr(user, 'stripped'):
+            mess.to = user.stripped
+        else:
+            mess.to = user
+
+        mess.type = message_type
+        mess.frm = mess.to
+
+        self.send_message(mess)

--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -298,15 +298,5 @@ class IRCBackend(ErrBot):
         channels = self.conn.channels.keys()
         return [IRCMUCRoom(node=channel) for channel in channels]
 
-    def send(self, user, text, in_reply_to=None, message_type='chat'):
-        """Sends a simple message to the specified user."""
-
-        nick_reply = config.__dict__.get('IRC_NICK_PREFIX_REPLY', False)
-
-        if in_reply_to and message_type == 'groupchat' and nick_reply:
-            super().send(user,
-                         '{}: {}'.format(in_reply_to.nick, text),
-                         in_reply_to,
-                         message_type)
-        else:
-            super().send(user, text, in_reply_to, message_type)
+    def groupchat_reply_format(self):
+        return '{0}: {1}'

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -208,6 +208,9 @@ class TestBackend(ErrBot):
             r = MUCRoom(jid=room)
             return r
 
+    def groupchat_reply_format(self):
+        return '{0} {1}'
+
 
 def pop_message(timeout=5, block=True):
     return outgoing_message_queue.get(timeout=timeout, block=block)

--- a/errbot/backends/text.py
+++ b/errbot/backends/text.py
@@ -73,6 +73,9 @@ class TextBackend(ErrBot):
     def rooms(self):
         return self.rooms
 
+    def groupchat_reply_format(self):
+        return '{0} {1}'
+
 
 class TextMUCRoom(MUCRoom):
     def __init__(self, jid=None, node='', domain='', resource=''):

--- a/errbot/backends/tox.py
+++ b/errbot/backends/tox.py
@@ -418,3 +418,6 @@ class ToxBackend(ErrBot):
             if gc.node == room:
                 return gc
         return None
+
+    def groupchat_reply_format(self):
+        return '@{0} {1}'

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -510,3 +510,6 @@ class XMPPBackend(ErrBot):
             An instance of :class:`~XMPPMUCRoom`.
         """
         return XMPPMUCRoom(room)
+
+    def groupchat_reply_format(self):
+        return '@{0} {1}'

--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -288,12 +288,12 @@ class BotPlugin(BotPluginBase):
         """
         return holder.bot.warn_admins(warning)
 
-    def send(self, user, text, in_reply_to=None, message_type='chat'):
+    def send(self, user, text, in_reply_to=None, message_type='chat', groupchat_nick_reply=False):
         """
             Sends asynchronously a message to a room or a user.
              if it is a room message_type needs to by 'groupchat' and user the room.
         """
-        return holder.bot.send(user, text, in_reply_to, message_type)
+        return holder.bot.send(user, text, in_reply_to, message_type, groupchat_nick_reply)
 
     def send_stream_request(self, user, fsource, name=None, size=None, stream_type=None):
         """

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -250,3 +250,7 @@ REVERSE_CHATROOM_RELAY = {}
 # to a value of 0 effectively disables rate limiting.
 #IRC_CHANNEL_RATE = 1  # Regular channel messages
 #IRC_PRIVATE_RATE = 1  # Private messages
+
+# Allow messages sent in a chatroom to be directed at requester.
+#IRC_NICK_PREFIX_REPLY = False
+

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -252,5 +252,5 @@ REVERSE_CHATROOM_RELAY = {}
 #IRC_PRIVATE_RATE = 1  # Private messages
 
 # Allow messages sent in a chatroom to be directed at requester.
-#IRC_NICK_PREFIX_REPLY = False
+#GROUPCHAT_NICK_PREFIXED = False
 

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -73,6 +73,8 @@ def bot_config_defaults(config):
         config.DIVERT_TO_PRIVATE = ()
     if not hasattr(config, 'MESSAGE_SIZE_LIMIT'):
         config.MESSAGE_SIZE_LIMIT = 10000  # Corresponds with what HipChat accepts
+    if not hasattr(config, 'GROUPCHAT_NICK_PREFIXED'):
+        config.GROUPCHAT_NICK_PREFIXED = False
 
 
 class ErrBot(Backend, StoreMixin):


### PR DESCRIPTION
Its a working override of the send() method. If this works, we should be able to do the same for the hipchat backend.

This should only apply to messages initiated in a groupchat with
'in_reply_to' specified in the send() method. Messages initiated
from a private message (chat) should not be affected.