### PR TITLE
Added simple initscript from debian-wheezy-like Linux distros

### DIFF
--- a/scripts/initscript.debian7
+++ b/scripts/initscript.debian7
@@ -12,17 +12,29 @@
 ### END INIT INFO
 
 CONFIG_DIR=/etc/errbot/
-PIDFILE=$CONFIG_DIR/err/err.pid
+
+# get BOT_DATA_DIR
+pushd . 2>&1 > /dev/null
+cd $CONFIG_DIR
+BOT_DATA_DIR=`python -c "from config import BOT_DATA_DIR ; print BOT_DATA_DIR"`
+popd 2>&1 > /dev/null
+
+PIDFILE=$BOT_DATA_DIR/err.pid
 ERR=/usr/local/bin/err.py
 BACKEND="--irc"
 
 case "$1" in
 start)  echo "Enabling errbot:"
-
+        pushd . 2>&1 > /dev/null
+        cd $CONFIG_DIR
         $ERR --config $CONFIG_DIR --daemon $BACKEND
+        popd  2>&1 > /dev/null
         ;;
 stop)   echo "Disabling errbot"
+        pushd . 2>&1 > /dev/null
+        cd $CONFIG_DIR
         kill -9 `cat $PIDFILE`
+        popd  2>&1 > /dev/null
         ;;
 restart) echo "Restarting errbot"
         /etc/init.d/errbot stop

--- a/scripts/initscript.debian7
+++ b/scripts/initscript.debian7
@@ -1,0 +1,37 @@
+#!/bin/bash
+### BEGIN INIT INFO
+# Provides:          errbot
+# Required-Start:    networking
+# Required-Stop:     
+# Should-Start:      
+# Should-Stop:       
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: start errbot
+# Description:       errbot.py a cool multi-protocol bot
+### END INIT INFO
+
+CONFIG_DIR=/etc/errbot/
+PIDFILE=$CONFIG_DIR/err/err.pid
+ERR=/usr/local/bin/err.py
+BACKEND="--irc"
+
+case "$1" in
+start)  echo "Enabling errbot:"
+
+        $ERR --config $CONFIG_DIR --daemon $BACKEND
+        ;;
+stop)   echo "Disabling errbot"
+        kill -9 `cat $PIDFILE`
+        ;;
+restart) echo "Restarting errbot"
+        /etc/init.d/errbot stop
+        /etc/init.d/errbot start
+        ;;
+reload|force-reload) echo "Not implemented yet."
+        ;;
+*)      echo "Usage: /etc/init.d/errbot {start|stop|restart|reload|force-reload}"
+        exit 2
+        ;;
+esac
+exit 0


### PR DESCRIPTION
This is a fairly simple script, and of course is meant to be basicly customized  by the user who is installing err.

Basically, what is meant to be customized is:

* The `CONFIG_DIR` variable
* The `ERR` variable, in order to point to the err.py script
* The `BACKEND` variable, to choose the backend.

Hope this helps.
