### PR TITLE
Adding new plugin

### DIFF
--- a/errbot/repos.py
+++ b/errbot/repos.py
@@ -134,4 +134,8 @@ KNOWN_PUBLIC_REPOS = {
         'https://github.com/vaz-ar/err-linksBot.git',
         'Plugin to handle links posted in chatrooms'
     ),
+    'err-stash': (
+        'https://github.com/charlesrg/err-stash.git',
+        'Plugin to notify commits to Atlassian Stash Git repo to user or chatrooms.'
+    ),    
 }

--- a/errbot/repos.py
+++ b/errbot/repos.py
@@ -137,5 +137,5 @@ KNOWN_PUBLIC_REPOS = {
     'err-stash': (
         'https://github.com/charlesrg/err-stash.git',
         'Plugin to notify commits to Atlassian Stash Git repo to user or chatrooms.'
-    ),    
+    ),
 }


### PR DESCRIPTION
Plugin is used to show commits from Stash (Git Repo Manager from Atlassian) to a chatroom. It takes advantage of Stash built in webhook.