### PR TITLE
Autoinstaller for missing plugins dependencies

### DIFF
--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -31,7 +31,16 @@ BOT_DATA_DIR = '/var/lib/err'
 # locally before publishing it. Note that you can specify only a single
 # directory, however you are free to create subdirectories with multiple
 # plugins inside this directory.
-BOT_EXTRA_PLUGIN_DIR = None 
+BOT_EXTRA_PLUGIN_DIR = None
+
+# If True, when you err wants to start a plugin and a dependency from
+# requirements.txt of the plugin is missing, it will automatically invoke
+# pip install --user for the missing dependencies.
+# It will detect if the bot is running in a virtualenv and if yes, it
+# will install it in the virtualenv instead of on the user.
+#
+# Note: be sure to give the proper autorizations to the user running the bot.
+AUTOINSTALL_DEPS = True
 
 # The location of the log file. If you set this to None, then logging will
 # happen to console only.

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -33,14 +33,16 @@ BOT_DATA_DIR = '/var/lib/err'
 # plugins inside this directory.
 BOT_EXTRA_PLUGIN_DIR = None
 
-# If True, when you err wants to start a plugin and a dependency from
-# requirements.txt of the plugin is missing, it will automatically invoke
-# pip install --user for the missing dependencies.
-# It will detect if the bot is running in a virtualenv and if yes, it
-# will install it in the virtualenv instead of on the user.
+
+# Should plugin dependencies be installed automatically? If this is true
+# then Err will use pip to install any missing dependencies automatically.
 #
-# Note: be sure to give the proper autorizations to the user running the bot.
-AUTOINSTALL_DEPS = True
+# If you have installed Err in a virtualenv, this will run the equivalent
+# of `pip install -r requirements.txt`.
+# If no virtualenv is detected, the equivalent of `pip install --user -r
+# requirements.txt` is used to ensure the package(s) is/are only installed for
+# the user running Err.
+#AUTOINSTALL_DEPS = True
 
 # The location of the log file. If you set this to None, then logging will
 # happen to console only.

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -79,7 +79,6 @@ def bot_config_defaults(config):
         config.AUTOINSTALL_DEPS = False
 
 
-
 class ErrBot(Backend, StoreMixin):
     """ ErrBot is the layer of Err that takes care of the plugin management and dispatching
     """

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -75,6 +75,9 @@ def bot_config_defaults(config):
         config.MESSAGE_SIZE_LIMIT = 10000  # Corresponds with what HipChat accepts
     if not hasattr(config, 'GROUPCHAT_NICK_PREFIXED'):
         config.GROUPCHAT_NICK_PREFIXED = False
+    if not hasattr(config, 'AUTOINSTALL_DEPS'):
+        config.AUTOINSTALL_DEPS = False
+
 
 
 class ErrBot(Backend, StoreMixin):
@@ -170,7 +173,7 @@ class ErrBot(Backend, StoreMixin):
     def update_dynamic_plugins(self):
         all_candidates, errors = update_plugin_places(
             [self.plugin_dir + os.sep + d for d in self.get(REPOS, {}).keys()],
-            self.bot_config.BOT_EXTRA_PLUGIN_DIR)
+            self.bot_config.BOT_EXTRA_PLUGIN_DIR, self.bot_config.AUTOINSTALL_DEPS)
         self.all_candidates = all_candidates
         return errors
 

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -31,16 +31,18 @@ class IncompatiblePluginException(Exception):
 class PluginConfigurationException(Exception):
     pass
 
+
 def find_plugin_roots(path):
     """ Recursively find the plugins from the given path.
     It is usefull so you can give a root directory of checked out plugins and
     it will discover them automatically.
     """
-    plugin_roots = []
+    plugin_roots = set()  # you can have several .plug per directory.
     for root, dirnames, filenames in os.walk(path):
         for filename in fnmatch.filter(filenames, '*.plug'):
-            plugin_roots.append(os.path.dirname(os.path.join(root, filename)))
+            plugin_roots.add(os.path.dirname(os.path.join(root, filename)))
     return plugin_roots
+
 
 def get_preloaded_plugins(extra):
     # adds the extra plugin dir from the setup for developers convenience
@@ -186,6 +188,7 @@ def reload_plugin_by_name(name):
     new_class = getattr(module, class_name)
     plugin.plugin_object.__class__ = new_class
 
+
 def install_package(package):
     if hasattr(sys, 'real_prefix'):
         # this is a virtualenv, so we can use it directly
@@ -194,6 +197,7 @@ def install_package(package):
         # otherwise only install it as a user package
         pip.main(['install', '--user', package])
     globals()[package] = importlib.import_module(package)
+
 
 def update_plugin_places(path_list, extra_plugin_dir, autoinstall_deps=True):
     builtins = get_preloaded_plugins(extra_plugin_dir)
@@ -211,10 +215,9 @@ def update_plugin_places(path_list, extra_plugin_dir, autoinstall_deps=True):
             for dep in deps_to_install:
                 logging.info("Trying to install an unmet dependency: %s" % dep)
                 install_package(dep)
-        errors =[]
+        errors = []
     else:
-        errors = [dependencies_result[0] for result in dependencies_result]
-    errors = [error for error in errors if error is not None]
+        errors = [result[0] for result in dependencies_result if result is not None]
     simplePluginManager.setPluginPlaces(chain(builtins, path_list))
     all_candidates = []
 

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -1,8 +1,11 @@
 from configparser import NoSectionError
 from itertools import chain
+import importlib
+import fnmatch
 import logging
 import sys
 import os
+import pip
 from . import PY2
 from .botplugin import BotPlugin
 from .utils import version2array, PY3
@@ -28,22 +31,34 @@ class IncompatiblePluginException(Exception):
 class PluginConfigurationException(Exception):
     pass
 
+def find_plugin_roots(path):
+    """ Recursively find the plugins from the given path.
+    It is usefull so you can give a root directory of checked out plugins and
+    it will discover them automatically.
+    """
+    plugin_roots = []
+    for root, dirnames, filenames in os.walk(path):
+        for filename in fnmatch.filter(filenames, '*.plug'):
+            plugin_roots.append(os.path.dirname(os.path.join(root, filename)))
+    return plugin_roots
 
-def get_builtins(extra):
+def get_preloaded_plugins(extra):
     # adds the extra plugin dir from the setup for developers convenience
+    all_builtins_and_extra = [BUILTIN]
     if extra:
         if isinstance(extra, list):
-            return [BUILTIN] + extra
-        return [BUILTIN, extra]
-    else:
-        return [BUILTIN]
+            for path in extra:
+                all_builtins_and_extra.extend(find_plugin_roots(path))
+        else:
+            all_builtins_and_extra.extend(find_plugin_roots(extra))
+    return all_builtins_and_extra
 
 
 def init_plugin_manager():
     global simplePluginManager
 
     if not holder.plugin_manager:
-        logging.info('init plugin manager')
+        logging.debug('init plugin manager')
         simplePluginManager = PluginManager(categories_filter={"bots": BotPlugin})
         simplePluginManager.setPluginInfoExtension('plug')
         holder.plugin_manager = simplePluginManager
@@ -171,14 +186,34 @@ def reload_plugin_by_name(name):
     new_class = getattr(module, class_name)
     plugin.plugin_object.__class__ = new_class
 
+def install_package(package):
+    if hasattr(sys, 'real_prefix'):
+        # this is a virtualenv, so we can use it directly
+        pip.main(['install', package])
+    else:
+        # otherwise only install it as a user package
+        pip.main(['install', '--user', package])
+    globals()[package] = importlib.import_module(package)
 
-def update_plugin_places(path_list, extra_plugin_dir):
-    builtins = get_builtins(extra_plugin_dir)
-    for entry in chain(builtins, path_list):
+def update_plugin_places(path_list, extra_plugin_dir, autoinstall_deps=True):
+    builtins = get_preloaded_plugins(extra_plugin_dir)
+    paths = builtins + path_list
+    for entry in paths:
         if entry not in sys.path:
-            sys.path.append(entry)  # so the plugins can relatively import their submodules
-
-    errors = [check_dependencies(path) for path in path_list]
+            sys.path.append(entry)  # so plugins can relatively import their submodules
+    dependencies_result = [check_dependencies(path) for path in paths]
+    deps_to_install = set()
+    if autoinstall_deps:
+        for result in dependencies_result:
+            if result:
+                deps_to_install.update(result[1])
+        if deps_to_install:
+            for dep in deps_to_install:
+                logging.info("Trying to install an unmet dependency: %s" % dep)
+                install_package(dep)
+        errors =[]
+    else:
+        errors = [dependencies_result[0] for result in dependencies_result]
     errors = [error for error in errors if error is not None]
     simplePluginManager.setPluginPlaces(chain(builtins, path_list))
     all_candidates = []
@@ -224,6 +259,10 @@ def global_restart():
 
 
 def check_dependencies(path):
+    """ This methods returns a pair of (message, packages missing).
+    Or None if everything is OK.
+    """
+    logging.debug("check dependencies of %s" % path)
     # noinspection PyBroadException
     try:
         from pkg_resources import get_distribution
@@ -242,7 +281,8 @@ def check_dependencies(path):
                 except Exception as _:
                     missing_pkg.append(stripped)
         if missing_pkg:
-            return ('You need those dependencies for %s: ' % path) + ','.join(missing_pkg)
+            return (('You need those dependencies for %s: ' % path) + ','.join(missing_pkg),
+                    missing_pkg)
         return None
     except Exception as _:
-        return 'You need to have setuptools installed for the dependency check of the plugins'
+        return ('You need to have setuptools installed for the dependency check of the plugins', [])


### PR DESCRIPTION
This adds an option so err can autoinstall the missing requirements from plugins requirements.txt

It also makes the preloaded (either builtins and extra) plugins loading more consistent with the rest (it will go through the subdirectory and properly detect all the plugin roots).