### PR TITLE
Hipchat keepalive fixes

### DIFF
--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -316,6 +316,12 @@ class HipchatBackend(XMPPBackend):
         super(HipchatBackend, self).__init__(config)
 
     def create_connection(self):
+        # HipChat connections time out with the default keepalive interval
+        # so use a lower value that is known to work, but only if the user
+        # does not specify their own value in their config.
+        if self.keepalive is None:
+            self.keepalive = 60
+
         return HipchatClient(
             jid=self.jid,
             password=self.password,

--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -289,7 +289,6 @@ class HipChatMUCRoom(MUCRoom):
 class HipchatClient(XMPPConnection):
     def __init__(self, *args, **kwargs):
         self.token = kwargs.pop('token')
-        self.debug = kwargs.pop('debug')
         self.hypchat = hypchat.HypChat(self.token)
         super().__init__(*args, **kwargs)
 
@@ -317,7 +316,14 @@ class HipchatBackend(XMPPBackend):
         super(HipchatBackend, self).__init__(config)
 
     def create_connection(self):
-        return HipchatClient(self.jid, password=self.password, debug=[], token=self.api_token)
+        return HipchatClient(
+            jid=self.jid,
+            password=self.password,
+            feature=self.feature,
+            keepalive=self.keepalive,
+            ca_cert=self.ca_cert,
+            token=self.api_token,
+        )
 
     @property
     def mode(self):

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -261,8 +261,11 @@ class XMPPMUCOccupant(MUCOccupant):
 
 
 class XMPPConnection(object):
-    def __init__(self, jid, password, feature={}, keepalive=None, ca_cert=None):
+    def __init__(self, jid, password, feature=None, keepalive=None, ca_cert=None):
+        if feature is not None:
+            feature = {}
         self.connected = False
+
         self.client = ClientXMPP(str(jid), password, plugin_config={'feature_mechanisms': feature})
         self.client.register_plugin('xep_0030')  # Service Discovery
         self.client.register_plugin('xep_0045')  # Multi-User Chat

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -385,7 +385,13 @@ class XMPPBackend(ErrBot):
         self._room_topics = {}
 
     def create_connection(self):
-        return XMPPConnection(self.jid, self.password, self.feature, self.keepalive, self.ca_cert)
+        return XMPPConnection(
+            jid=self.jid,
+            password=self.password,
+            feature=self.feature,
+            keepalive=self.keepalive,
+            ca_cert=self.ca_cert
+        )
 
     def incoming_message(self, xmppmsg):
         """Callback for message events"""


### PR DESCRIPTION
This PR fixes a long-standing bug where `XMPP_KEEPALIVE_INTERVAL` wasn't being honored, and, if the user hasn't specified it in their config, uses a better default for HipChat (because the SleekXMPP default of 3600 works fine just about anywhere except for on HipChat).