### PR TITLE
added a server parameter for XMPP

### DIFF
--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -261,10 +261,11 @@ class XMPPMUCOccupant(MUCOccupant):
 
 
 class XMPPConnection(object):
-    def __init__(self, jid, password, feature=None, keepalive=None, ca_cert=None):
+    def __init__(self, jid, password, feature=None, keepalive=None, ca_cert=None, server=None):
         if feature is not None:
             feature = {}
         self.connected = False
+        self.server = server
 
         self.client = ClientXMPP(str(jid), password, plugin_config={'feature_mechanisms': feature})
         self.client.register_plugin('xep_0030')  # Service Discovery
@@ -293,7 +294,10 @@ class XMPPConnection(object):
 
     def connect(self):
         if not self.connected:
-            self.client.connect()
+            if server:
+                self.client.connect(server)
+            else:
+                self.client.connect()
             self.connected = True
         return self
 
@@ -368,6 +372,7 @@ class XMPPBackend(ErrBot):
 
         self.jid = Identifier(identity['username'])
         self.password = identity['password']
+        self.server = identity.get(['server'], None)
         self.feature = config.__dict__.get('XMPP_FEATURE_MECHANISMS', {})
         self.keepalive = config.__dict__.get('XMPP_KEEPALIVE_INTERVAL', None)
         self.ca_cert = config.__dict__.get('XMPP_CA_CERT_FILE', '/etc/ssl/certs/ca-certificates.crt')
@@ -390,7 +395,8 @@ class XMPPBackend(ErrBot):
             password=self.password,
             feature=self.feature,
             keepalive=self.keepalive,
-            ca_cert=self.ca_cert
+            ca_cert=self.ca_cert,
+            server=self.server
         )
 
     def incoming_message(self, xmppmsg):

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -294,7 +294,7 @@ class XMPPConnection(object):
 
     def connect(self):
         if not self.connected:
-            if server:
+            if server is not None:
                 self.client.connect(server)
             else:
                 self.client.connect()

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -77,6 +77,7 @@ BOT_IDENTITY = {
     # XMPP (Jabber) mode
     'username': 'err@localhost',  # The JID of the user you have created for the bot
     'password': 'changeme',       # The corresponding password for this user
+    # 'server': ('host.domain.tld',5222), # server override
 
     ## HipChat mode (Comment the above if using this mode)
     # 'username' : '12345_123456@chat.hipchat.com',


### PR DESCRIPTION
It is needed if you want to be able to force an XMPP server to connect to instead of relying on SRV records or direct resolution.