### PR TITLE
Avoid Identity -> str -> Identity transformations.

### DIFF
--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -709,7 +709,7 @@ class Backend(object):
             # stripped returns the full bot@conference.domain.tld/chat_username
             # but in case of a groupchat, we should only try to send to the MUC address
             # itself (bot@conference.domain.tld)
-            response.to = mess.frm.stripped.split('/')[0]
+            response.to = mess.frm.node
         elif str(mess.to) == self.bot_config.BOT_IDENTITY['username']:
             # This is a direct private message, not initiated through a MUC. Use
             # stripped to remove the resource so that the response goes to the

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -709,7 +709,7 @@ class Backend(object):
             # stripped returns the full bot@conference.domain.tld/chat_username
             # but in case of a groupchat, we should only try to send to the MUC address
             # itself (bot@conference.domain.tld)
-            response.to = mess.frm.node
+            response.to = Identifier(node=mess.frm.node, domain=mess.frm.domain)
         elif str(mess.to) == self.bot_config.BOT_IDENTITY['username']:
             # This is a direct private message, not initiated through a MUC. Use
             # stripped to remove the resource so that the response goes to the

--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -194,7 +194,7 @@ class IRCConnection(SingleServerIRCBot):
 
     def on_pubmsg(self, _, e):
         msg = Message(e.arguments[0], type_='groupchat')
-        msg.frm = e.target
+        msg.frm = Identifier(node=e.target)
         msg.to = self.callback.jid
         msg.nick = e.source.split('!')[0]  # FIXME find the real nick in the channel
         self.callback.callback_message(msg)


### PR DESCRIPTION
Stringifying and parsing back the string as Identity makes the code
brittle.
For example a room called '#gbin/err' broke the reply to the room codepath.