### PR TITLE
Completely revamped backup feature

### DIFF
--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -57,7 +57,7 @@ class BotPluginBase(StoreMixin):
             super(Gnagna, self).activate())
         """
         self.init_storage()
-        holder.bot.inject_commands_from(self)
+        self._bot.inject_commands_from(self)
         self.is_activated = True
 
     def deactivate(self):

--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -44,17 +44,20 @@ class BotPluginBase(StoreMixin):
     def bot_config(self):
         return self._bot.bot_config
 
-    def activate(self):
-        """
-            Override if you want to do something at initialization phase (don't forget to
-            super(Gnagna, self).activate())
-        """
+    def init_storage(self):
         classname = self.__class__.__name__
         log.debug('Init storage for %s' % classname)
         filename = os.path.join(self.bot_config.BOT_DATA_DIR, PLUGINS_SUBDIR, classname + '.db')
         log.debug('Loading %s' % filename)
         self.open_storage(filename)
-        self._bot.inject_commands_from(self)
+
+    def activate(self):
+        """
+            Override if you want to do something at initialization phase (don't forget to
+            super(Gnagna, self).activate())
+        """
+        self.init_storage()
+        holder.bot.inject_commands_from(self)
         self.is_activated = True
 
     def deactivate(self):

--- a/errbot/core_plugins/backup.plug
+++ b/errbot/core_plugins/backup.plug
@@ -1,0 +1,9 @@
+[Core]
+Name = Backup
+Module = backup
+
+[Documentation]
+Description = This core plugin manage import and export of data from Err.
+
+[Python]
+Version = 2+

--- a/errbot/core_plugins/backup.py
+++ b/errbot/core_plugins/backup.py
@@ -1,6 +1,6 @@
 from errbot import BotPlugin, botcmd
-from errbot.holder import bot
 from errbot.plugin_manager import get_all_plugins
+from errbot import holder
 import os
 
 
@@ -16,8 +16,8 @@ class Backup(BotPlugin):
         with open(filename, 'w') as f:
             f.write('## This file is not executable on its own. use err.py -r FILE to restore your bot.\n\n')
             f.write('log.info("Restoring core configs.")\n')
-            for key in bot:
-                f.write('bot["'+key+'"] = ' + repr(bot[key]) + '\n')
+            for key in holder.bot:
+                f.write('bot["'+key+'"] = ' + repr(holder.bot[key]) + '\n')
 
             f.write('log.info("Installing plugins.")\n')
             f.write('for repo in bot["repos"]:\n')
@@ -37,4 +37,4 @@ class Backup(BotPlugin):
                         f.write('pobj["'+key+'"] = ' + repr(pobj[key]) + '\n')
                     f.write('pobj.close_storage()\n')
 
-        return "The backup file has been writen in '%s'" % filename
+        return "The backup file has been written in '%s'" % filename

--- a/errbot/core_plugins/backup.py
+++ b/errbot/core_plugins/backup.py
@@ -3,38 +3,38 @@ from errbot.holder import bot
 from errbot.plugin_manager import get_all_plugins
 import os
 
+
 class Backup(BotPlugin):
-  @botcmd(admin_only=True)
-  def backup(self, msg, args):
-    """Backup everything.
-       Makes a backup script called backup.py in the data bot directory.
-       You can restore the backup from the command line with err.py --restore
-    """
-    filename = os.path.join(self.bot_config.BOT_DATA_DIR, 'backup.py')
-    with open(filename, 'w') as f:
-      f.write('## This file is not executable on its own. use err.py -r FILE to restore your bot.\n\n')
-      f.write('log.info("Restoring core configs.")\n')
-      for key in bot:
-        f.write('bot["'+key+'"] = ' + repr(bot[key]) + '\n')
+    """ Backup related commands. """
+    @botcmd(admin_only=True)
+    def backup(self, msg, args):
+        """Backup everything.
+           Makes a backup script called backup.py in the data bot directory.
+           You can restore the backup from the command line with err.py --restore
+        """
+        filename = os.path.join(self.bot_config.BOT_DATA_DIR, 'backup.py')
+        with open(filename, 'w') as f:
+            f.write('## This file is not executable on its own. use err.py -r FILE to restore your bot.\n\n')
+            f.write('log.info("Restoring core configs.")\n')
+            for key in bot:
+                f.write('bot["'+key+'"] = ' + repr(bot[key]) + '\n')
 
-      f.write('log.info("Installing plugins.")\n')
-      f.write('for repo in bot["repos"]:\n')
-      f.write('   errors = bot.install(repo)\n')
-      f.write('   for error in errors:\n')
-      f.write('      log.error(error)\n')
+            f.write('log.info("Installing plugins.")\n')
+            f.write('for repo in bot["repos"]:\n')
+            f.write('   errors = bot.install(repo)\n')
+            f.write('   for error in errors:\n')
+            f.write('      log.error(error)\n')
 
-      f.write('log.info("Restoring plugins data.")\n')
+            f.write('log.info("Restoring plugins data.")\n')
 
-      for plug in get_all_plugins():
-        pobj = plug.plugin_object
-        if pobj.shelf:
-          f.write('pobj = get_plugin_by_name("' + plug.name + '").plugin_object\n')
-          f.write('pobj.init_storage()\n')
+            for plug in get_all_plugins():
+                pobj = plug.plugin_object
+                if pobj.shelf:
+                    f.write('pobj = get_plugin_by_name("' + plug.name + '").plugin_object\n')
+                    f.write('pobj.init_storage()\n')
 
-          for key in pobj.shelf:
-            f.write('pobj["'+key+'"] = ' + repr(pobj[key]) + '\n')
-          f.write('pobj.close_storage()\n')
+                    for key in pobj.shelf:
+                        f.write('pobj["'+key+'"] = ' + repr(pobj[key]) + '\n')
+                    f.write('pobj.close_storage()\n')
 
-
-    return "The backup file has been writen in '%s'" % filename
-
+        return "The backup file has been writen in '%s'" % filename

--- a/errbot/core_plugins/backup.py
+++ b/errbot/core_plugins/backup.py
@@ -1,0 +1,28 @@
+from errbot import BotPlugin, botcmd
+from errbot.holder import bot
+from errbot.plugin_manager import get_all_plugins
+import os
+
+class Backup(BotPlugin):
+  @botcmd
+  def backup(self, msg, args):
+    """Backup everything.
+       Makes a backup script called backup.py in the data bot directory.
+    """
+    filename = os.path.join(self.bot_config.BOT_DATA_DIR, 'backup.py')
+    with open(filename, 'w') as f:
+      f.write('from errbot.holder import bot\n')
+      f.write('from errbot.plugin_manager import get_plugin_by_name\n\n')
+      for key in bot:
+        f.write('bot["'+key+'"] = ' + repr(bot[key]) + '\n')
+      for plug in get_all_plugins():
+        pobj = plug.plugin_object
+        if pobj.shelf:
+          f.write('pobj = get_plugin_by_name("' + plug.name + '").plugin_object\n')
+          for key in pobj.shelf:
+            f.write('pobj["'+key+'"] = ' + repr(pobj[key]) + '\n')
+
+
+    return "The backup file has been writen in '%s'" % filename
+
+

--- a/errbot/core_plugins/backup.py
+++ b/errbot/core_plugins/backup.py
@@ -1,6 +1,4 @@
 from errbot import BotPlugin, botcmd
-from errbot.plugin_manager import get_all_plugins
-from errbot import holder
 import os
 
 
@@ -16,8 +14,8 @@ class Backup(BotPlugin):
         with open(filename, 'w') as f:
             f.write('## This file is not executable on its own. use err.py -r FILE to restore your bot.\n\n')
             f.write('log.info("Restoring core configs.")\n')
-            for key in holder.bot:
-                f.write('bot["'+key+'"] = ' + repr(holder.bot[key]) + '\n')
+            for key in self._bot:  # don't mimic that in real plugins, this is core only.
+                f.write('bot["'+key+'"] = ' + repr(self._bot[key]) + '\n')
 
             f.write('log.info("Installing plugins.")\n')
             f.write('for repo in bot["repos"]:\n')
@@ -27,7 +25,7 @@ class Backup(BotPlugin):
 
             f.write('log.info("Restoring plugins data.")\n')
 
-            for plug in get_all_plugins():
+            for plug in self._bot.getAllPlugins():
                 pobj = plug.plugin_object
                 if pobj.shelf:
                     f.write('pobj = get_plugin_by_name("' + plug.name + '").plugin_object\n')

--- a/errbot/core_plugins/backup.py
+++ b/errbot/core_plugins/backup.py
@@ -4,25 +4,37 @@ from errbot.plugin_manager import get_all_plugins
 import os
 
 class Backup(BotPlugin):
-  @botcmd
+  @botcmd(admin_only=True)
   def backup(self, msg, args):
     """Backup everything.
        Makes a backup script called backup.py in the data bot directory.
+       You can restore the backup from the command line with err.py --restore
     """
     filename = os.path.join(self.bot_config.BOT_DATA_DIR, 'backup.py')
     with open(filename, 'w') as f:
-      f.write('from errbot.holder import bot\n')
-      f.write('from errbot.plugin_manager import get_plugin_by_name\n\n')
+      f.write('## This file is not executable on its own. use err.py -r FILE to restore your bot.\n\n')
+      f.write('log.info("Restoring core configs.")\n')
       for key in bot:
         f.write('bot["'+key+'"] = ' + repr(bot[key]) + '\n')
+
+      f.write('log.info("Installing plugins.")\n')
+      f.write('for repo in bot["repos"]:\n')
+      f.write('   errors = bot.install(repo)\n')
+      f.write('   for error in errors:\n')
+      f.write('      log.error(error)\n')
+
+      f.write('log.info("Restoring plugins data.")\n')
+
       for plug in get_all_plugins():
         pobj = plug.plugin_object
         if pobj.shelf:
           f.write('pobj = get_plugin_by_name("' + plug.name + '").plugin_object\n')
+          f.write('pobj.init_storage()\n')
+
           for key in pobj.shelf:
             f.write('pobj["'+key+'"] = ' + repr(pobj[key]) + '\n')
+          f.write('pobj.close_storage()\n')
 
 
     return "The backup file has been writen in '%s'" % filename
-
 

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -519,8 +519,8 @@ class ErrBot(Backend, StoreMixin, BotPluginManager):
         else:
             self.send(
                 mess.frm,
-                ("A new plugin repository named %s has been installed correctly from "
-                 "%s. Refreshing the plugins commands..." % (human_name, args)),
+                ("A new plugin repository has been installed correctly from "
+                 "%s. Refreshing the plugins commands..." % args),
                 message_type=mess.type
             )
         self.activate_non_started_plugins()

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -381,41 +381,6 @@ class ErrBot(Backend, StoreMixin, BotPluginManager):
 
     # noinspection PyUnusedLocal
     @botcmd(admin_only=True)
-    def export_configs(self, mess, args):
-        """ Returns all the configs in form of a string you can backup
-        """
-        return repr(self.get(CONFIGS, {}))
-
-    # noinspection PyUnusedLocal
-    @botcmd(admin_only=True)
-    def import_configs(self, mess, args):
-        """ Restore the configs from an export from !export configs
-        It will merge with preexisting configurations.
-        """
-        orig = self.get(CONFIGS, {})
-        added = literal_eval(args)
-        if type(added) is not dict:
-            raise Exception('Weird, it should be a dictionary')
-        self[CONFIGS] = dict(list(orig.items()) + list(added.items()))
-        return "Import is done correctly, there are %i config entries now." % len(self[CONFIGS])
-
-    # noinspection PyUnusedLocal
-    @botcmd(admin_only=True)
-    def zap_configs(self, mess, args):
-        """ WARNING : Deletes all the configuration of all the plugins
-        """
-        self[CONFIGS] = {}
-        return "Done"
-
-    # noinspection PyUnusedLocal
-    @botcmd(admin_only=True)
-    def repos_export(self, mess, args):
-        """ Returns all the repos in form of a string you can backup
-        """
-        return str(self.get_installed_plugin_repos())
-
-    # noinspection PyUnusedLocal
-    @botcmd(admin_only=True)
     def restart(self, mess, args):
         """ restart the bot """
         self.send(mess.frm, "Deactivating all the plugins...")

--- a/errbot/main.py
+++ b/errbot/main.py
@@ -52,7 +52,7 @@ def setup_bot(bot_class, logger, config, restore = None):
         bot = holder.bot  # gives the bot to the script
         if 'repos' in bot:
             log.fatal('You cannot restore onto a non empty bot.')
-        from errbot.plugin_manager import get_plugin_by_name
+        from errbot.plugin_manager import get_plugin_by_name  # noqa
         log.info('**** RESTORING the bot from %s' % restore)
         with open(restore) as f:
             exec(f.read())

--- a/errbot/main.py
+++ b/errbot/main.py
@@ -5,7 +5,7 @@ import sys
 log = logging.getLogger(__name__)
 
 
-def setup_bot(bot_class, logger, config, restore = None):
+def setup_bot(bot_class, logger, config, restore=None):
     # from here the environment is supposed to be set (daemon / non daemon,
     # config.py in the python path )
 
@@ -49,7 +49,6 @@ def setup_bot(bot_class, logger, config, restore = None):
     # restore the bot from the restore script
     if restore:
         # Prepare the context for the restore script
-        bot = holder.bot  # gives the bot to the script
         if 'repos' in bot:
             log.fatal('You cannot restore onto a non empty bot.')
         from errbot.plugin_manager import get_plugin_by_name  # noqa
@@ -60,13 +59,13 @@ def setup_bot(bot_class, logger, config, restore = None):
         print('Restore complete restore the bot normally')
         sys.exit(0)
 
-    errors = holder.bot.update_dynamic_plugins()
+    errors = bot.update_dynamic_plugins()
     if errors:
         log.error('Some plugins failed to load:\n' + '\n'.join(errors))
     return bot
 
 
-def main(bot_class, logger, config, restore = None):
+def main(bot_class, logger, config, restore=None):
     bot = setup_bot(bot_class, logger, config, restore)
     log.debug('serve from %s' % bot)
     bot.serve_forever()

--- a/errbot/main.py
+++ b/errbot/main.py
@@ -1,11 +1,11 @@
 from os import path, makedirs
 import logging
+import sys
 
 log = logging.getLogger(__name__)
 
 
-def setup_bot(bot_class, logger, config):
-
+def setup_bot(bot_class, logger, config, restore = None):
     # from here the environment is supposed to be set (daemon / non daemon,
     # config.py in the python path )
 
@@ -45,13 +45,28 @@ def setup_bot(bot_class, logger, config):
     except Exception:
         log.exception("Unable to configure the backend, please check if your config.py is correct.")
         exit(-1)
-    errors = bot.update_dynamic_plugins()
+
+    # restore the bot from the restore script
+    if restore:
+        # Prepare the context for the restore script
+        bot = holder.bot  # gives the bot to the script
+        if 'repos' in bot:
+            log.fatal('You cannot restore onto a non empty bot.')
+        from errbot.plugin_manager import get_plugin_by_name
+        log.info('**** RESTORING the bot from %s' % restore)
+        with open(restore) as f:
+            exec(f.read())
+        bot.close_storage()
+        print('Restore complete restore the bot normally')
+        sys.exit(0)
+
+    errors = holder.bot.update_dynamic_plugins()
     if errors:
         log.error('Some plugins failed to load:\n' + '\n'.join(errors))
     return bot
 
 
-def main(bot_class, logger, config):
-    bot = setup_bot(bot_class, logger, config)
+def main(bot_class, logger, config, restore = None):
+    bot = setup_bot(bot_class, logger, config, restore)
     log.debug('serve from %s' % bot)
     bot.serve_forever()

--- a/errbot/storage.py
+++ b/errbot/storage.py
@@ -24,14 +24,14 @@ class StoreMixin(MutableMapping):
     """
 
     def __init__(self):
+        log.info('Init shelf of %s' % self.__class__.__name__)
         self.shelf = None
 
     def open_storage(self, path):
         if hasattr(self, 'shelf') and self.shelf is not None:
             raise StoreAlreadyOpenError("Storage appears to be opened already")
-        log.info("Try to open db file %s" % path)
         self.shelf = shelve.DbfilenameShelf(path, protocol=2)
-        log.debug('Opened shelf of %s' % self.__class__.__name__)
+        log.info('Opened shelf of %s at %s' % (self.__class__.__name__, path))
 
     def close_storage(self):
         if not hasattr(self, 'shelf') or self.shelf is None:

--- a/run_tests.py
+++ b/run_tests.py
@@ -16,6 +16,10 @@ else:
     print("Running under Python 2, skipping pep8 style checks")
     pep8_result = 0
 
+if pep8_result != 0:
+    print("Pep8 failed.")
+    sys.exit(-1)
+
 pytest_result = pytest.main('-x')
 
 if pytest_result or pep8_result:

--- a/tests/base_backend_tests.py
+++ b/tests/base_backend_tests.py
@@ -28,16 +28,18 @@ from errbot.utils import mess_2_embeddablehtml  # noqa
 LONG_TEXT_STRING = "This is a relatively long line of output, but I am repeated multiple times.\n"
 
 
+class Config:
+    BOT_IDENTITY = {'username': 'err@localhost'}
+    BOT_ASYNC = False
+    BOT_PREFIX = '!'
+    CHATROOM_FN = 'blah'
+
+
 class DummyBackend(Backend):
     outgoing_message_queue = Queue()
     jid = Identifier('err@localhost/err')
 
     def __init__(self, extra_config={}):
-        class Config:
-            BOT_IDENTITY = {'username': 'err@localhost'}
-            BOT_ASYNC = False
-            BOT_PREFIX = '!'
-            CHATROOM_FN = 'blah'
         self.bot_config = Config()
         for key in extra_config:
             setattr(self.bot_config, key, extra_config[key])

--- a/tests/commands_tests.py
+++ b/tests/commands_tests.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-from ast import literal_eval
 
 # create a mock configuration
 from errbot.backends.test import FullStackTest, push_message, pop_message
@@ -46,10 +45,6 @@ class TestCommands(FullStackTest):
         self.assertIn('GC 0->', pop_message())
 
     def test_config_cycle(self):
-        # test the full configuration cycle help, get set and export, import
-        push_message('!zap configs')
-        self.assertIn('Done', pop_message())
-
         push_message('!config Webserver')
         m = pop_message()
         self.assertIn('Default configuration for this plugin (you can copy and paste this directly as a command)', m)
@@ -62,15 +57,6 @@ class TestCommands(FullStackTest):
         m = pop_message()
         self.assertIn('Current configuration', m)
         self.assertIn('localhost', m)
-
-        push_message('!export configs')
-        configs = pop_message()
-        self.assertIn('localhost', configs)
-        obj = literal_eval(configs)  # be sure it is parseable
-        obj['Webserver']['HOST'] = 'localhost'
-
-        push_message('!import configs ' + repr(obj))
-        self.assertIn('Import is done correctly', pop_message())
 
         push_message('!config Webserver')
         self.assertIn('localhost', pop_message())
@@ -109,9 +95,6 @@ class TestCommands(FullStackTest):
         push_message('!repos install git://github.com/gbin/err-helloworld.git')
         self.assertIn('err-helloworld', pop_message(timeout=60))
         self.assertIn('reload', pop_message())
-
-        push_message('!repos export')  # should appear in the export
-        self.assertEqual("{'err-helloworld': 'git://github.com/gbin/err-helloworld.git'}", pop_message())
 
         push_message('!help hello')  # should appear in the help
         self.assertEqual("this command says hello", pop_message())

--- a/tests/commands_tests.py
+++ b/tests/commands_tests.py
@@ -4,6 +4,7 @@
 from errbot.backends.test import FullStackTest, push_message, pop_message
 from queue import Empty
 import unittest
+import re
 
 
 class TestCommands(FullStackTest):
@@ -131,6 +132,19 @@ class TestCommands(FullStackTest):
 
         push_message('!hello')  # should not respond
         self.assertIn('Command "hello" not found', pop_message())
+
+    def test_backup(self):
+        push_message('!repos install git://github.com/gbin/err-helloworld.git')
+        self.assertIn('err-helloworld', pop_message(timeout=60))
+        self.assertIn('reload', pop_message())
+        push_message('!backup')
+        msg = pop_message()
+        self.assertIn('has been written in', msg)
+        filename = re.search(r"'([A-Za-z0-9_\./\\-]*)'", msg).group(1)
+        # At least the backup should mention the installed plugin
+
+        self.assertIn('err-helloworld', open(filename).read())
+        push_message('!repos uninstall err-helloworld')
 
     def test_encoding_preservation(self):
         push_message('!echo へようこそ')


### PR DESCRIPTION
Now a single chat command creates an online backup:
!backup

Then you can store safely the backup.py script created.

When you lost your bot, you can restore it from an empty instance with: 
   err -r [FILE]
or
   err --restore [FILE]

It will reinstall all the previously installed plugin, restore their settings then restore their shelf data.