### PR TITLE
Removed holder from backends.

### DIFF
--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -1,7 +1,6 @@
 import logging
 import sys
 
-from errbot import holder
 from errbot.backends.base import MUCOccupant, MUCRoom, RoomDoesNotExistError
 from errbot.backends.xmpp import XMPPBackend, XMPPConnection
 from errbot.utils import parse_jid
@@ -48,14 +47,15 @@ class HipChatMUCRoom(MUCRoom):
     This class represents a Multi-User Chatroom.
     """
 
-    def __init__(self, name):
+    def __init__(self, name, bot=None):
         """
             :param name:
                 The name of the room
             """
         super().__init__()
-        self.hypchat = holder.bot.conn.hypchat
-        self.xep0045 = holder.bot.conn.client.plugin['xep_0045']
+        self._bot = bot
+        self.hypchat = bot.conn.hypchat
+        self.xep0045 = bot.conn.client.plugin['xep_0045']
         self._name = name
 
     @property
@@ -114,16 +114,16 @@ class HipChatMUCRoom(MUCRoom):
 
         room = self.jid
         self.xep0045.joinMUC(room, username, password=password, wait=True)
-        holder.bot.conn.add_event_handler(
+        self._bot.conn.add_event_handler(
             "muc::{}::got_online".format(room),
-            holder.bot.user_joined_chat
+            self._bot.user_joined_chat
         )
-        holder.bot.conn.add_event_handler(
+        self._bot.conn.add_event_handler(
             "muc::{}::got_offline".format(room),
-            holder.bot.user_left_chat
+            self._bot.user_left_chat
         )
 
-        holder.bot.callback_room_joined(self)
+        self._bot.callback_room_joined(self)
         log.info("Joined room {}".format(self.name))
 
     def leave(self, reason=None):
@@ -138,16 +138,16 @@ class HipChatMUCRoom(MUCRoom):
         room = self.jid
         try:
             self.xep0045.leaveMUC(room=room, nick=self.xep0045.ourNicks[room], msg=reason)
-            holder.bot.conn.del_event_handler(
+            self._bot.conn.del_event_handler(
                 "muc::{}::got_online".format(room),
-                holder.bot.user_joined_chat
+                self._bot.user_joined_chat
             )
-            holder.bot.conn.del_event_handler(
+            self._bot.conn.del_event_handler(
                 "muc::{}::got_offline".format(room),
-                holder.bot.user_left_chat
+                self._bot.user_left_chat
             )
             log.info("Left room {}".format(self))
-            holder.bot.callback_room_left(self)
+            self._bot.callback_room_left(self)
         except KeyError:
             log.debug("Trying to leave {} while not in this room".format(self))
 
@@ -255,7 +255,7 @@ class HipChatMUCRoom(MUCRoom):
             of the user you wish to invite.
         """
         room = self.room
-        users = holder.bot.conn.users
+        users = self._bot.conn.users
 
         for person in args:
             try:
@@ -351,7 +351,7 @@ class HipchatBackend(XMPPBackend):
         :returns:
             A list of :class:`~HipChatMUCRoom` instances.
         """
-        xep0045 = holder.bot.conn.client.plugin['xep_0045']
+        xep0045 = self.conn.client.plugin['xep_0045']
         rooms = {}
         # Build a mapping of xmpp_jid->name for easy reference
         for room in self.conn.hypchat.rooms(expand='items')['items']:

--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -3,7 +3,6 @@ import logging
 import sys
 import warnings
 
-from errbot import holder
 from errbot.backends.base import (
     Identifier, Message, MUCOccupant, MUCRoom, RoomError, RoomNotJoinedError,
     build_message, build_text_html_message_pair,
@@ -35,7 +34,8 @@ except ImportError as _:
 class IRCMUCRoom(MUCRoom):
     def __init__(self, *args, **kwargs):
         super(IRCMUCRoom, self).__init__(*args, **kwargs)
-        self.connection = holder.bot.conn.connection
+        self._bot = kwargs['bot']
+        self.connection = self._bot.conn.connection
 
     def join(self, username=None, password=None):
         """
@@ -51,7 +51,7 @@ class IRCMUCRoom(MUCRoom):
         room = str(self)
 
         self.connection.join(room, key=password)
-        holder.bot.callback_room_joined(self)
+        self._bot.callback_room_joined(self)
         log.info("Joined room {}".format(room))
 
     def leave(self, reason=None):
@@ -67,7 +67,7 @@ class IRCMUCRoom(MUCRoom):
 
         self.connection.part(room, reason)
         log.info("Left room {}".format(room))
-        holder.bot.callback_room_left(self)
+        self._bot.callback_room_left(self)
 
     def create(self):
         """
@@ -107,7 +107,7 @@ class IRCMUCRoom(MUCRoom):
         :getter:
             Returns `True` if the room has been joined, `False` otherwise.
         """
-        return str(self) in holder.bot.conn.channels.keys()
+        return str(self) in self._bot.conn.channels.keys()
 
     @property
     def topic(self):
@@ -142,7 +142,7 @@ class IRCMUCRoom(MUCRoom):
         """
         occupants = []
         try:
-            for nick in holder.bot.conn.channels[str(self)].users():
+            for nick in self._bot.conn.channels[str(self)].users():
                 occupants.append(MUCOccupant(node=nick))
         except KeyError:
             raise RoomNotJoinedError("Must be in a room in order to see occupants.")
@@ -283,7 +283,7 @@ class IRCBackend(ErrBot):
         :returns:
             An instance of :class:`~IRCMUCRoom`.
         """
-        return IRCMUCRoom(node=room)
+        return IRCMUCRoom(node=room, bot=self)
 
     @property
     def mode(self):

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -3,7 +3,6 @@ import logging
 import re
 import time
 import sys
-from errbot import holder
 from errbot import PY3
 from errbot.backends.base import (
     Message, build_message, Identifier, Presence, ONLINE, AWAY,
@@ -328,13 +327,13 @@ class SlackBackend(ErrBot):
 
     def query_room(self, room):
         if room.startswith('C') or room.startswith('G'):
-            return SlackRoom(domain=room)
+            return SlackRoom(domain=room, bot=self)
 
         m = SLACK_CLIENT_CHANNEL_HYPERLINK.match(room)
         if m is not None:
-            return SlackRoom(domain=m.groupdict()['id'])
+            return SlackRoom(domain=m.groupdict()['id'], bot=self)
 
-        return SlackRoom(name=room)
+        return SlackRoom(name=room, bot=self)
 
     def rooms(self):
         """
@@ -344,14 +343,14 @@ class SlackBackend(ErrBot):
             A list of :class:`~SlackRoom` instances.
         """
         channels = self.channels(joined_only=True, exclude_archived=True)
-        return [SlackRoom(domain=channel['id']) for channel in channels]
+        return [SlackRoom(domain=channel['id'], bot=self) for channel in channels]
 
     def groupchat_reply_format(self):
         return '@{0}: {1}'
 
 
 class SlackRoom(MUCRoom):
-    def __init__(self, jid=None, node='', domain='', resource='', name=None):
+    def __init__(self, jid=None, node='', domain='', resource='', name=None, bot=None):
         if jid is not None or node != '' or resource != '':
             raise ValueError("SlackRoom() only supports construction using domain or name")
         if domain != '' and name is not None:
@@ -363,10 +362,11 @@ class SlackRoom(MUCRoom):
             else:
                 self._name = name
         else:
-            self._name = holder.bot.channelid_to_channelname(domain)
+            self._name = bot.channelid_to_channelname(domain)
 
         self._id = None
-        self.sc = holder.bot.sc
+        self._bot = bot
+        self.sc = bot.sc
 
     def __str__(self):
         return "#%s" % self.name
@@ -376,7 +376,7 @@ class SlackRoom(MUCRoom):
         """
         The channel object exposed by SlackClient
         """
-        id = holder.bot.sc.server.channels.find(self.name)
+        id = self.sc.server.channels.find(self.name)
         if id is None:
             raise RoomDoesNotExistError(
                 "%s does not exist (or is a private group you don't have access to)" % str(self)
@@ -393,9 +393,9 @@ class SlackRoom(MUCRoom):
           * https://api.slack.com/methods/groups.list
         """
         if self.private:
-            return holder.bot.api_call('groups.info', data={'channel': self.id})["group"]
+            return self._bot.api_call('groups.info', data={'channel': self.id})["group"]
         else:
-            return holder.bot.api_call('channels.info', data={'channel': self.id})["channel"]
+            return self._bot.api_call('channels.info', data={'channel': self.id})["channel"]
 
     @property
     def private(self):
@@ -416,42 +416,42 @@ class SlackRoom(MUCRoom):
 
     def join(self, username=None, password=None):
         logging.info("Joining channel %s" % str(self))
-        holder.bot.api_call('channels.join', data={'name': self.name})
+        self._bot.api_call('channels.join', data={'name': self.name})
 
     def leave(self, reason=None):
         if self.id.startswith('C'):
             logging.info("Leaving channel %s (%s)" % (str(self), self.id))
-            holder.bot.api_call('channels.leave', data={'channel': self.id})
+            self._bot.api_call('channels.leave', data={'channel': self.id})
         else:
             logging.info("Leaving group %s (%s)" % (str(self), self.id))
-            holder.bot.api_call('groups.leave', data={'channel': self.id})
+            self._bot.api_call('groups.leave', data={'channel': self.id})
         self._id = None
 
     def create(self, private=False):
         if private:
             logging.info("Creating group %s" % str(self))
-            holder.bot.api_call('groups.create', data={'name': self.name})
+            self._bot.api_call('groups.create', data={'name': self.name})
         else:
             logging.info("Creating channel %s" % str(self))
-            holder.bot.api_call('channels.create', data={'name': self.name})
+            self._bot.api_call('channels.create', data={'name': self.name})
 
     def destroy(self):
         if self.id.startswith('C'):
             logging.info("Archiving channel %s (%s)" % (str(self), self.id))
-            holder.bot.api_call('channels.archive', data={'channel': self.id})
+            self._bot.api_call('channels.archive', data={'channel': self.id})
         else:
             logging.info("Archiving group %s (%s)" % (str(self), self.id))
-            holder.bot.api_call('groups.archive', data={'channel': self.id})
+            self._bot.api_call('groups.archive', data={'channel': self.id})
         self._id = None
 
     @property
     def exists(self):
-        channels = holder.bot.channels(joined_only=False, exclude_archived=False)
+        channels = self._bot.channels(joined_only=False, exclude_archived=False)
         return len([c for c in channels if c['name'] == self.name]) > 0
 
     @property
     def joined(self):
-        channels = holder.bot.channels(joined_only=True)
+        channels = self._bot.channels(joined_only=True)
         return len([c for c in channels if c['name'] == self.name]) > 0
 
     @property
@@ -465,10 +465,10 @@ class SlackRoom(MUCRoom):
     def topic(self, topic):
         if self.private:
             logging.info("Setting topic of %s (%s) to '%s'" % (str(self), self.id, topic))
-            holder.bot.api_call('groups.setTopic', data={'channel': self.id, 'topic': topic})
+            self._bot.api_call('groups.setTopic', data={'channel': self.id, 'topic': topic})
         else:
             logging.info("Setting topic of %s (%s) to '%s'" % (str(self), self.id, topic))
-            holder.bot.api_call('channels.setTopic', data={'channel': self.id, 'topic': topic})
+            self._bot.api_call('channels.setTopic', data={'channel': self.id, 'topic': topic})
 
     @property
     def purpose(self):
@@ -481,28 +481,28 @@ class SlackRoom(MUCRoom):
     def purpose(self, purpose):
         if self.private:
             logging.info("Setting purpose of %s (%s) to '%s'" % (str(self), self.id, purpose))
-            holder.bot.api_call('groups.setPurpose', data={'channel': self.id, 'purpose': purpose})
+            self._bot.api_call('groups.setPurpose', data={'channel': self.id, 'purpose': purpose})
         else:
             logging.info("Setting purpose of %s (%s) to '%s'" % (str(self), self.id, purpose))
-            holder.bot.api_call('channels.setPurpose', data={'channel': self.id, 'purpose': purpose})
+            self._bot.api_call('channels.setPurpose', data={'channel': self.id, 'purpose': purpose})
 
     @property
     def occupants(self):
         members = self._channel_info['members']
         return [SlackMUCOccupant(
                 node=self.name,
-                domain=holder.bot.sc.server.domain,
-                resource=holder.bot.userid_to_username(m))
+                domain=self._bot.sc.server.domain,
+                resource=self._bot.userid_to_username(m))
                 for m in members]
 
     def invite(self, *args):
-        users = {user['name']: user['id'] for user in holder.bot.api_call('users.list')['members']}
+        users = {user['name']: user['id'] for user in self._bot.api_call('users.list')['members']}
         for user in args:
             if user not in users:
                 raise UserDoesNotExistError("User '%s' not found" % user)
             logging.info("Inviting %s into %s (%s)" % (user, str(self), self.id))
             method = 'groups.invite' if self.private else 'channels.invite'
-            response = holder.bot.api_call(
+            response = self._bot.api_call(
                 method,
                 data={'channel': self.id, 'user': users[user]},
                 raise_errors=False

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -8,7 +8,6 @@ from errbot.backends.base import (
 )
 from errbot.backends.base import ONLINE, OFFLINE, AWAY, DND
 from errbot.errBot import ErrBot
-from errbot import holder
 from threading import Thread
 from time import sleep
 
@@ -63,7 +62,8 @@ def verify_gtalk_cert(xmpp_client):
 class XMPPMUCRoom(MUCRoom):
     def __init__(self, *args, **kwargs):
         super(XMPPMUCRoom, self).__init__(*args, **kwargs)
-        self.xep0045 = holder.bot.conn.client.plugin['xep_0045']
+        self._bot = kwargs['bot']
+        self.xep0045 = self._bot.conn.client.plugin['xep_0045']
 
     def join(self, username=None, password=None):
         """
@@ -74,13 +74,13 @@ class XMPPMUCRoom(MUCRoom):
         """
         room = str(self)
         self.xep0045.joinMUC(str(self), username, password=password, wait=True)
-        holder.bot.conn.add_event_handler(
+        self._bot.conn.add_event_handler(
             "muc::{}::got_online".format(room),
-            holder.bot.user_joined_chat
+            self._bot.user_joined_chat
         )
-        holder.bot.conn.add_event_handler(
+        self._bot.conn.add_event_handler(
             "muc::{}::got_offline".format(room),
-            holder.bot.user_left_chat
+            self._bot.user_left_chat
         )
         # Room configuration can only be done once a MUC presence stanza
         # has been received from the server. This HAS to take place in a
@@ -88,7 +88,7 @@ class XMPPMUCRoom(MUCRoom):
         t = Thread(target=self.configure)
         t.setDaemon(True)
         t.start()
-        holder.bot.callback_room_joined(self)
+        self._bot.callback_room_joined(self)
         log.info("Joined room {}".format(room))
 
     def leave(self, reason=None):
@@ -104,16 +104,16 @@ class XMPPMUCRoom(MUCRoom):
         try:
             self.xep0045.leaveMUC(room=room, nick=self.xep0045.ourNicks[room], msg=reason)
 
-            holder.bot.conn.del_event_handler(
+            self._bot.conn.del_event_handler(
                 "muc::{}::got_online".format(room),
-                holder.bot.user_joined_chat
+                self._bot.user_joined_chat
             )
-            holder.bot.conn.del_event_handler(
+            self._bot.conn.del_event_handler(
                 "muc::{}::got_offline".format(room),
-                holder.bot.user_left_chat
+                self._bot.user_left_chat
             )
             log.info("Left room {}".format(room))
-            holder.bot.callback_room_left(self)
+            self._bot.callback_room_left(self)
         except KeyError:
             log.debug("Trying to leave {} while not in this room".format(room))
 
@@ -175,7 +175,7 @@ class XMPPMUCRoom(MUCRoom):
         if not self.joined:
             raise RoomNotJoinedError("Must be in a room in order to see the topic.")
         try:
-            return holder.bot._room_topics[str(self)]
+            return self._bot._room_topics[str(self)]
         except KeyError:
             return None
 
@@ -262,9 +262,10 @@ class XMPPMUCOccupant(MUCOccupant):
 
 
 class XMPPConnection(object):
-    def __init__(self, jid, password, feature=None, keepalive=None, ca_cert=None, server=None):
+    def __init__(self, jid, password, feature=None, keepalive=None, ca_cert=None, server=None, bot=None):
         if feature is not None:
             feature = {}
+        self._bot = bot
         self.connected = False
         self.server = server
 
@@ -327,7 +328,7 @@ class XMPPConnection(object):
             "MUCRoom class instead.",
             DeprecationWarning
         )
-        holder.bot.query_room(room).join(username=username, password=password)
+        self._bot.query_room(room).join(username=username, password=password)
 
     def configure_room(self, room):
         """
@@ -345,7 +346,7 @@ class XMPPConnection(object):
             "MUCRoom class instead.",
             DeprecationWarning
         )
-        holder.bot.query_room(room).configure()
+        self._bot.query_room(room).configure()
 
     def invite_in_room(self, room, jids_to_invite):
         """
@@ -357,7 +358,7 @@ class XMPPConnection(object):
             "MUCRoom class instead.",
             DeprecationWarning,
         )
-        holder.bot.query_room(room).invite(jids_to_invite)
+        self._bot.query_room(room).invite(jids_to_invite)
 
 XMPP_TO_ERR_STATUS = {'available': ONLINE,
                       'away': AWAY,
@@ -397,7 +398,8 @@ class XMPPBackend(ErrBot):
             feature=self.feature,
             keepalive=self.keepalive,
             ca_cert=self.ca_cert,
-            server=self.server
+            server=self.server,
+            bot=self
         )
 
     def incoming_message(self, xmppmsg):
@@ -513,8 +515,8 @@ class XMPPBackend(ErrBot):
         :returns:
             A list of :class:`~errbot.backends.base.XMPPMUCRoom` instances.
         """
-        xep0045 = holder.bot.client.plugin['xep_0045']
-        return [XMPPMUCRoom(room) for room in xep0045.getJoinedRooms()]
+        xep0045 = self.client.plugin['xep_0045']
+        return [XMPPMUCRoom(room, bot=self) for room in xep0045.getJoinedRooms()]
 
     def query_room(self, room):
         """
@@ -525,7 +527,7 @@ class XMPPBackend(ErrBot):
         :returns:
             An instance of :class:`~XMPPMUCRoom`.
         """
-        return XMPPMUCRoom(room)
+        return XMPPMUCRoom(room, bot=self)
 
     def groupchat_reply_format(self):
         return '@{0} {1}'


### PR DESCRIPTION
A backend inherits from ErrBot so there is no reason a backend should
use holder.