### PR TITLE
Implement generic reconnection logic

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -12,7 +12,7 @@ from errbot.backends.base import (
 from errbot.errBot import ErrBot
 from errbot.utils import deprecated
 
-log = log.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 try:
     from functools import lru_cache

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -96,18 +96,6 @@ class SlackBackend(ErrBot):
             sys.exit(1)
         self.sc = SlackClient(self.token)
 
-        log.debug("Verifying authentication token")
-        self.auth = self.api_call("auth.test", raise_errors=False)
-        if not self.auth['ok']:
-            log.fatal("Couldn't authenticate with Slack. Server said: %s" % self.auth['error'])
-            sys.exit(1)
-        log.debug("Token accepted")
-        self.jid = SlackIdentifier(
-            node=self.auth["user_id"],
-            domain=self.sc.server.domain,
-            resource=self.auth["user_id"]
-        )
-
     def api_call(self, method, data=None, raise_errors=True):
         """
         Make an API call to the Slack API and return response data.
@@ -135,6 +123,17 @@ class SlackBackend(ErrBot):
         return response
 
     def serve_once(self):
+        log.info("Verifying authentication token")
+        self.auth = self.api_call("auth.test", raise_errors=False)
+        if not self.auth['ok']:
+            log.error("Couldn't authenticate with Slack. Server said: %s" % self.auth['error'])
+        log.debug("Token accepted")
+        self.jid = SlackIdentifier(
+            node=self.auth["user_id"],
+            domain=self.sc.server.domain,
+            resource=self.auth["user_id"]
+        )
+
         log.info("Connecting to Slack real-time-messaging API")
         if self.sc.rtm_connect():
             log.info("Connected")


### PR DESCRIPTION
Some back-ends currently implement reconnection logic because the
underlying libraries (irc, SleekXMPP) support this. This commit
introduces a generic, back-end agnostic reconnection system with
exponential backoff and randomized jitter that any back-end can use,
irrespective of whether or not the underlying library offers this.

The reason for this change is to support reconnection on Slack and any
other future back-ends that don't support this natively.

It has been a conscious decision to implement this logic in Err
rather than in python-slackclient directly because doing so would make
it impossible to trigger `disconnect_callback` on disconnections. This
is because the IRC and SleekXMPP libraries are threaded and implement a
callback for this event, but SlackClient is not, so if it handled
reconnections internally there would be no way to signal Err to trigger
`disconnect_callback`.

Fixes #362.