### PR TITLE
[slack] Handle message_changed and message_deleted properly

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -206,14 +206,40 @@ class SlackBackend(ErrBot):
             log.warning("Unknown message type! Unable to handle")
             return
 
-        msg = Message(event['text'], type_=message_type)
+        subtype = event.get('subtype', None)
+        if subtype == "message_deleted":
+            log.debug("Message of type message_deleted, ignoring this event")
+            return
+        if subtype == "message_changed" and 'attachments' in event['message']:
+            # If you paste a link into Slack, it does a call-out to grab details
+            # from it so it can display this in the chatroom. These show up as
+            # message_changed events with an 'attachments' key in the embedded
+            # message. We should completely ignore these events otherwise we
+            # could end up processing bot commands twice (user issues a command
+            # containing a link, it gets processed, then Slack triggers the
+            # message_changed event and we end up processing it again as a new
+            # message. This is not what we want).
+            log.debug(
+                "Ignoring message_changed event with attachments, likely caused "
+                "by Slack auto-expanding a link"
+            )
+            return
+
+        if 'message' in event:
+            text = event['message']['text']
+            user = event['message']['user']
+        else:
+            text = event['text']
+            user = event['user']
+
+        msg = Message(text, type_=message_type)
         msg.frm = SlackIdentifier(
-            node=self.channelid_to_channelname(event['channel']),
+            node=self.channelid_to_channelname(channel),
             domain=self.sc.server.domain,
-            resource=self.userid_to_username(event['user'])
+            resource=self.userid_to_username(user)
         )
         msg.to = SlackIdentifier(
-            node=self.channelid_to_channelname(event['channel']),
+            node=self.channelid_to_channelname(channel),
             domain=self.sc.server.domain,
             resource=self.sc.server.username
         )


### PR DESCRIPTION
Fixes #380.

* `message_changed` events will be processed as if they're a new message (Err currently has no concept of saying a message was changed, and relating the changed message to the original message. Implementing such a thing is something that would be cool, but out of scope for this issue.)

* Pasting in a link makes Slack expand it automatically, which shows up as a `message_changed` event also. We try to detect this and ignore these to avoid such a message from being treated as two.

* `message_deleted` events are detected but completely ignored.