### PR TITLE
Removing XMPP semantics from Err.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.venv
 *.pyc
 /.idea
 /atlassian-ide-plugin.xml

--- a/errbot/backends/__init__.py
+++ b/errbot/backends/__init__.py
@@ -1,17 +1,35 @@
-class SimpleIdentifier(str):
+class SimpleIdentifier(object):
     """ This is an identifier just represented as a string.
         DO NOT USE THIS DIRECTLY AS IT IS NOT COMPATIBLE WITH MOST BACKENDS,
         use self.build_identifier(identifier_as_string) instead.
     """
 
+    def  __init__(self, usr):
+       self._person = usr
+
     @property
     def person(self):
         """This needs to return the part of the identifier pointing to a person.
         For example for XMPP it is node@domain without the resource that actually maps to a device."""
-        return self
+        return self._person
+
+    def __unicode__(self):
+        return self._person
+    __str__ = __unicode__
 
 
 class SimpleMUCOccupant(SimpleIdentifier):
     """ This is a MUC occupant represented as a string.
         DO NOT USE THIS DIRECTLY AS IT IS NOT COMPATIBLE WITH MOST BACKENDS,
     """
+    def  __init__(self, idd):
+       person, room = idd.split('@')
+       super().__init__(person)
+       self._room = room
+
+    @property
+    def room(self):
+       return self._room
+
+    def __unicode__(self):
+        return self._person + '@' + self._room

--- a/errbot/backends/__init__.py
+++ b/errbot/backends/__init__.py
@@ -33,3 +33,6 @@ class SimpleMUCOccupant(SimpleIdentifier):
 
     def __unicode__(self):
         return self._person + '@' + self._room
+
+    def __eq__(self, other):
+        return self.person == other.person and self.room == other.room

--- a/errbot/backends/__init__.py
+++ b/errbot/backends/__init__.py
@@ -4,8 +4,8 @@ class SimpleIdentifier(object):
         use self.build_identifier(identifier_as_string) instead.
     """
 
-    def  __init__(self, usr):
-       self._person = usr
+    def __init__(self, usr):
+        self._person = usr
 
     @property
     def person(self):
@@ -22,14 +22,14 @@ class SimpleMUCOccupant(SimpleIdentifier):
     """ This is a MUC occupant represented as a string.
         DO NOT USE THIS DIRECTLY AS IT IS NOT COMPATIBLE WITH MOST BACKENDS,
     """
-    def  __init__(self, idd):
-       person, room = idd.split('@')
-       super().__init__(person)
-       self._room = room
+    def __init__(self, idd):
+        person, room = idd.split('@')
+        super().__init__(person)
+        self._room = room
 
     @property
     def room(self):
-       return self._room
+        return self._room
 
     def __unicode__(self):
         return self._person + '@' + self._room

--- a/errbot/backends/__init__.py
+++ b/errbot/backends/__init__.py
@@ -1,0 +1,18 @@
+class SimpleIdentifier(str):
+    """ This is an identifier just represented as a string.
+        DO NOT USE THIS DIRECTLY AS IT IS NOT COMPATIBLE WITH MOST BACKENDS,
+        use self.build_identifier(identifier_as_string) instead.
+    """
+
+    @property
+    def person(self):
+        """This needs to return the part of the identifier pointing to a person.
+        For example for XMPP it is node@domain without the resource that actually maps to a device."""
+        return self
+
+class SimpleMUCOccupant(SimpleIdentifier):
+    """ This is a MUC occupant represented as a string.
+        DO NOT USE THIS DIRECTLY AS IT IS NOT COMPATIBLE WITH MOST BACKENDS,
+    """
+
+

--- a/errbot/backends/__init__.py
+++ b/errbot/backends/__init__.py
@@ -10,9 +10,8 @@ class SimpleIdentifier(str):
         For example for XMPP it is node@domain without the resource that actually maps to a device."""
         return self
 
+
 class SimpleMUCOccupant(SimpleIdentifier):
     """ This is a MUC occupant represented as a string.
         DO NOT USE THIS DIRECTLY AS IT IS NOT COMPATIBLE WITH MOST BACKENDS,
     """
-
-

--- a/errbot/backends/__init__.py
+++ b/errbot/backends/__init__.py
@@ -2,6 +2,7 @@ import logging
 
 log = logging.getLogger(__name__)
 
+
 class DeprecationBridgeIdentifier(object):
     """This is a Deprecation bridge that will be removed.
     Originally identifier were mapped to XMPP, this emulate that with a deprecation notice.

--- a/errbot/backends/__init__.py
+++ b/errbot/backends/__init__.py
@@ -1,19 +1,51 @@
-class SimpleIdentifier(object):
+import logging
+
+log = logging.getLogger(__name__)
+
+class DeprecationBridgeIdentifier(object):
+    """This is a Deprecation bridge that will be removed.
+    Originally identifier were mapped to XMPP, this emulate that with a deprecation notice.
+    """
+    @property
+    def node(self):
+        log.warn('.node is deprecated on this type of identifier, use .person instead')
+        return self.person
+
+    @property
+    def domain(self):
+        log.warn('.domain is deprecated on this type of identifier and should not be used')
+        return ''
+
+    @property
+    def resource(self):
+        log.warn('.resource on this type of identifier is deprecated, use .client instead')
+        return self.client
+
+
+class SimpleIdentifier(DeprecationBridgeIdentifier):
     """ This is an identifier just represented as a string.
         DO NOT USE THIS DIRECTLY AS IT IS NOT COMPATIBLE WITH MOST BACKENDS,
         use self.build_identifier(identifier_as_string) instead.
     """
 
-    def __init__(self, usr):
+    def __init__(self, usr, client=None):
         self._person = usr
+        self._client = client
 
     @property
     def person(self):
-        """This needs to return the part of the identifier pointing to a person.
-        For example for XMPP it is node@domain without the resource that actually maps to a device."""
+        """This needs to return the part of the identifier pointing to a person."""
         return self._person
 
+    @property
+    def client(self):
+        """This needs to return the part of the identifier pointing to a client from which a person is sending a message from.
+        Returns None is unspecified"""
+        return self._client
+
     def __unicode__(self):
+        if self.client:
+            return self._person + "/" + self._client
         return self._person
     __str__ = __unicode__
 

--- a/errbot/backends/__init__.py
+++ b/errbot/backends/__init__.py
@@ -29,8 +29,8 @@ class SimpleIdentifier(DeprecationBridgeIdentifier):
         use self.build_identifier(identifier_as_string) instead.
     """
 
-    def __init__(self, usr, client=None):
-        self._person = usr
+    def __init__(self, person, client=None):
+        self._person = person
         self._client = client
 
     @property
@@ -50,13 +50,15 @@ class SimpleIdentifier(DeprecationBridgeIdentifier):
         return self._person
     __str__ = __unicode__
 
+    def __eq__(self, other):
+        return self.person == other.person
+
 
 class SimpleMUCOccupant(SimpleIdentifier):
     """ This is a MUC occupant represented as a string.
         DO NOT USE THIS DIRECTLY AS IT IS NOT COMPATIBLE WITH MOST BACKENDS,
     """
-    def __init__(self, idd):
-        person, room = idd.split('@')
+    def __init__(self, person, room):
         super().__init__(person)
         self._room = room
 
@@ -66,6 +68,8 @@ class SimpleMUCOccupant(SimpleIdentifier):
 
     def __unicode__(self):
         return self._person + '@' + self._room
+
+    __str__ = __unicode__
 
     def __eq__(self, other):
         return self.person == other.person and self.room == other.room

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -1067,7 +1067,9 @@ class Backend(object):
         return ''.join(filter(None, [top, description, usage, bottom]))
 
     def send(self, user, text, in_reply_to=None, message_type='chat', groupchat_nick_reply=False):
-        """Sends a simple message to the specified user."""
+        """Sends a simple message to the specified user.
+           user is a textual representation of its identity (backward compatibility).
+        """
 
         nick_reply = self.bot_config.GROUPCHAT_NICK_PREFIXED
 
@@ -1077,14 +1079,11 @@ class Backend(object):
             reply_text = text
 
         mess = self.build_message(reply_text)
-        if hasattr(user, 'stripped'):
-            mess.to = user.stripped
-        else:
-            mess.to = user
+        mess.to = self.build_identifier(user)
 
         if in_reply_to:
             mess.type = in_reply_to.type
-            mess.frm = in_reply_to.to.stripped
+            mess.frm = in_reply_to.to
         else:
             mess.type = message_type
             mess.frm = self.jid

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -12,7 +12,7 @@ from xml.etree import cElementTree as ET
 from xml.etree.cElementTree import ParseError
 
 from errbot import botcmd, PY2
-from errbot.utils import get_sender_username, xhtml2txt, parse_jid, split_string_after, deprecated
+from errbot.utils import get_sender_username, xhtml2txt, split_string_after, deprecated
 from errbot.templating import tenv
 from errbot.bundled.threadpool import ThreadPool, WorkRequest
 

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -42,74 +42,6 @@ class UserDoesNotExistError(Exception):
     on a user that doesn't exist"""
 
 
-class Identifier(object):
-    """
-    This class is the parent and the basic contract of all the ways the backends
-    are identifying a person on their system.
-    """
-
-    def __init__(self, jid=None, node='', domain='', resource=''):
-        if jid:
-            self._node, self._domain, self._resource = parse_jid(jid)
-        else:
-            self._node = node
-            self._domain = domain
-            self._resource = resource
-
-    @property
-    def node(self):
-        return self._node
-
-    @property
-    def domain(self):
-        return self._domain
-
-    @property
-    def resource(self):
-        return self._resource
-
-    @property
-    def stripped(self):
-        if self._domain:
-            return self._node + '@' + self._domain
-        return self._node  # if the backend has no domain notion
-
-    def bare_match(self, other):
-        """ checks if 2 identifiers are equal, ignoring the resource """
-        return other.stripped == self.stripped
-
-    def __str__(self):
-        answer = self.stripped
-        if self._resource:
-            answer += '/' + self._resource
-        return answer
-
-    def __unicode__(self):
-        return str(self.__str__())
-
-    # deprecated stuff ...
-
-    @deprecated(node)
-    def getNode(self):
-        """ will be removed on the next version """
-
-    @deprecated(domain)
-    def getDomain(self):
-        """ will be removed on the next version """
-
-    @deprecated(bare_match)
-    def bareMatch(self, other):
-        """ will be removed on the next version """
-
-    @deprecated(stripped)
-    def getStripped(self):
-        """ will be removed on the next version """
-
-    @deprecated(resource)
-    def getResource(self):
-        """ will be removed on the next version """
-
-
 class Message(object):
     """
     A chat message.
@@ -411,6 +343,9 @@ STREAM_REJECTED = 'rejected'
 
 DEFAULT_REASON = 'unknown'
 
+class Identifier(object):
+    def __init__(self, s):
+        raise NotImplemented('Identifier() should never be called directly, use self.build_identifier() instead.')
 
 class Stream(io.BufferedReader):
     """

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -859,7 +859,7 @@ class Backend(object):
             wr = WorkRequest(
                 self._execute_and_send,
                 [],
-                {'cmd': cmd, 'args': args, 'match': match, 'mess': mess, 'jid': jid,
+                {'cmd': cmd, 'args': args, 'match': match, 'mess': mess,
                  'template_name': f._err_command_template}
             )
             self.thread_pool.putRequest(wr)
@@ -868,22 +868,20 @@ class Backend(object):
                 # depleted so we don't have strange concurrency issues.
                 self.thread_pool.wait()
         else:
-            self._execute_and_send(cmd=cmd, args=args, match=match, mess=mess, jid=jid,
+            self._execute_and_send(cmd=cmd, args=args, match=match, mess=mess,
                                    template_name=f._err_command_template)
 
-    def _execute_and_send(self, cmd, args, match, mess, jid, template_name=None):
+    def _execute_and_send(self, cmd, args, match, mess, template_name=None):
         """Execute a bot command and send output back to the caller
 
         cmd: The command that was given to the bot (after being expanded)
         args: Arguments given along with cmd
         match: A re.MatchObject if command is coming from a regex-based command, else None
         mess: The message object
-        jid: The jid of the person executing the command
         template_name: The name of the template which should be used to render
             html-im output, if any
 
         """
-
         def process_reply(reply_):
             # integrated templating
             if template_name:
@@ -910,8 +908,8 @@ class Backend(object):
         except Exception as e:
             tb = traceback.format_exc()
             log.exception('An error happened while processing '
-                          'a message ("%s") from %s: %s"' %
-                          (mess.body, jid, tb))
+                          'a message ("%s"): %s"' %
+                          (mess.body, tb))
             send_reply(self.MSG_ERROR_OCCURRED + ':\n %s' % e)
 
     def is_admin(self, usr):

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -817,7 +817,7 @@ class Backend(object):
         username = jid.person
         user_cmd_history = self.cmd_history[username]
 
-        log.info("Processing command '{}' with parameters '{}' from {}/{}".format(cmd, args, jid, mess.nick))
+        log.info("Processing command '{}' with parameters '{}' from {}".format(cmd, args, jid))
 
         if (cmd, args) in user_cmd_history:
             user_cmd_history.remove((cmd, args))  # Avoids duplicate history items

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -246,6 +246,7 @@ class Message(object):
     def getMuckNick(self):
         """ will be removed on the next version """
 
+
 ONLINE = 'online'
 OFFLINE = 'offline'
 AWAY = 'away'

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -929,7 +929,7 @@ class Backend(object):
            usr in self.bot_config.ACCESS_CONTROLS[cmd]['denyusers']):
             raise ACLViolation("You're not allowed to access this command from this user")
         if typ == 'groupchat':
-            stripped = mess.frm.stripped
+            stripped = mess.frm.person
             if ('allowmuc' in self.bot_config.ACCESS_CONTROLS[cmd] and
                self.bot_config.ACCESS_CONTROLS[cmd]['allowmuc'] is False):
                 raise ACLViolation("You're not allowed to access this command from a chatroom")

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -1149,7 +1149,7 @@ class Backend(object):
     def build_message(self, text):
         raise NotImplementedError("It should be implemented specifically for your backend")
 
-    def build_identifier(self, text):
+    def build_identifier(self, text_representation):
         raise NotImplementedError("It should be implemented specifically for your backend")
 
     def serve_once(self):

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -92,7 +92,8 @@ class Message(object):
             An identifier from for example build_identifier().
         """
         if not hasattr(to, 'person'):
-           raise Exception('`to` not an Identifier as it misses the "person" property. `to` : %s (%s)' % (to, to.__class__))
+            raise Exception('`to` not an Identifier as it misses ''the "person" property. `to` : %s (%s)'
+                            % (to, to.__class__))
         self._to = to
 
     @property
@@ -137,7 +138,8 @@ class Message(object):
             An identifier from build_identifier.
         """
         if not hasattr(from_, 'person'):
-           raise Exception('`from_` not an Identifier as it misses the "person" property. from_ : %s (%s)' % (from_, from_.__class__))
+            raise Exception('`from_` not an Identifier as it misses the "person" property. from_ : %s (%s)'
+                            % (from_, from_.__class__))
         self._from = from_
 
     @property
@@ -663,7 +665,8 @@ class Backend(object):
         jid = mess.frm
         text = mess.body
         if not hasattr(mess.frm, 'person'):
-           raise Exception('mess.frm not an Identifier as it misses the "person" property. Class of frm : %s', mess.frm.__class__)
+            raise Exception('mess.frm not an Identifier as it misses the "person" property. Class of frm : %s'
+                            % mess.frm.__class__)
 
         username = mess.frm.person
         user_cmd_history = self.cmd_history[username]
@@ -937,7 +940,8 @@ class Backend(object):
             raise ACLViolation("You're not allowed to access this command from this user")
         if typ == 'groupchat':
             if not hasattr(mess.frm, 'room'):
-                raise Exception('mess.from from a room is not a MUCIdentifier as it misses the "room" property. Class of frm : %s', mess.frm.__class__)
+                raise Exception('mess.frm is not a MUCIdentifier as it misses the "room" property. Class of frm : %s'
+                                % mess.frm.__class__)
             room = str(mess.frm.room)
             if ('allowmuc' in self.bot_config.ACCESS_CONTROLS[cmd] and
                self.bot_config.ACCESS_CONTROLS[cmd]['allowmuc'] is False):

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -520,7 +520,7 @@ class MUCRoom(object):
         The room's occupants.
 
         :getter:
-            Returns a list of :class:`~errbot.backends.base.MUCOccupant` instances.
+            Returns a list of occupant identities.
         :raises:
             :class:`~MUCNotJoinedError` if the room has not yet been joined.
         """
@@ -1187,7 +1187,7 @@ class Backend(object):
         Query a room for information.
 
         :param room:
-            The JID/identifier of the room to query for.
+            The room to query for.
         :returns:
             An instance of :class:`~MUCRoom`.
         """
@@ -1214,6 +1214,3 @@ class Backend(object):
             A list of :class:`~errbot.backends.base.MUCRoom` instances.
         """
         raise NotImplementedError("It should be implemented specifically for your backend")
-
-
-

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -343,9 +343,6 @@ STREAM_REJECTED = 'rejected'
 
 DEFAULT_REASON = 'unknown'
 
-class Identifier(object):
-    def __init__(self, s):
-        raise NotImplemented('Identifier() should never be called directly, use self.build_identifier() instead.')
 
 class Stream(io.BufferedReader):
     """
@@ -439,14 +436,10 @@ class Stream(io.BufferedReader):
         return Stream(self._identifier, new_fsource, self._name, self._size, self._stream_type)
 
 
-class MUCRoom(Identifier):
+class MUCRoom(object):
     """
     This class represents a Multi-User Chatroom.
     """
-
-    def __init__(self, jid=None, node='', domain='', resource='', bot=None):
-        super().__init__(jid, node, domain, resource)
-        self._bot = bot
 
     def join(self, username=None, password=None):
         """
@@ -551,20 +544,6 @@ class MUCRoom(Identifier):
             One or more JID's to invite into the room.
         """
         raise NotImplementedError("It should be implemented specifically for your backend")
-
-
-class MUCOccupant(Identifier):
-    """
-    This class represents a person inside a MUC.
-
-    This class exists to expose additional information about occupants
-    inside a MUC. For example, the XMPP back-end may expose backend-specific
-    information such as the real JID of the occupant and whether or not
-    that person is a moderator or owner of the room.
-
-    See the parent class for additional details.
-    """
-    pass
 
 
 def build_text_html_message_pair(source):
@@ -1187,6 +1166,9 @@ class Backend(object):
         raise NotImplementedError("It should be implemented specifically for your backend")
 
     def build_message(self, text):
+        raise NotImplementedError("It should be implemented specifically for your backend")
+
+    def build_identifier(self, text):
         raise NotImplementedError("It should be implemented specifically for your backend")
 
     def serve_once(self):

--- a/errbot/backends/campfire.py
+++ b/errbot/backends/campfire.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 
-from errbot.backends.base import Message, build_message, Identifier
+from errbot.backends.base import Message, build_message
 from errbot.errBot import ErrBot
 from threading import Condition
 
@@ -32,9 +32,9 @@ class CampfireConnection(pyfire.Campfire):
 ENCODING_INPUT = sys.stdin.encoding
 
 
-class CampfireIdentifier(Identifier):
-    def __init__(self, s):
-        self._user = s   # it is just one room for the moment
+class CampfireIdentifier(object):
+    def __init__(self, user):
+        self._user = user   # it is just one room for the moment
 
     @property
     def user(self):
@@ -80,7 +80,7 @@ class CampfireBackend(ErrBot):
     def connect(self):
         if not self.conn:
             self.conn = CampfireConnection(self.subdomain, self.username, self.password, self.ssl)
-            self.jid = Identifier(self.username)
+            self.jid = CampfireIdentifier(self.username)
             self.room = self.conn.get_room_by_name(self.chatroom).name
             # put us by default in the first room
             # resource emulates the XMPP behavior in chatrooms

--- a/errbot/backends/campfire.py
+++ b/errbot/backends/campfire.py
@@ -31,6 +31,7 @@ class CampfireConnection(pyfire.Campfire):
 
 ENCODING_INPUT = sys.stdin.encoding
 
+
 class CampfireIdentifier(Identifier):
     def __init__(self, s):
         self._user = s   # it is just one room for the moment
@@ -38,6 +39,7 @@ class CampfireIdentifier(Identifier):
     @property
     def user(self):
         return self._user
+
 
 class CampfireBackend(ErrBot):
     exit_lock = Condition()

--- a/errbot/backends/graphic.py
+++ b/errbot/backends/graphic.py
@@ -215,7 +215,6 @@ class GraphicBackend(TextBackend):
         msg.frm = self.jid
         return msg  # rebuild a pure html snippet to include directly in the console html
 
-
     def send_message(self, mess):
         self.send(mess)
 

--- a/errbot/backends/graphic.py
+++ b/errbot/backends/graphic.py
@@ -4,7 +4,6 @@ import re
 import sys
 
 import errbot
-from errbot.backends import SimpleIdentifier
 from errbot.backends.base import Message, build_text_html_message_pair
 from errbot.backends.text import TextBackend   # we use that as we emulate MUC there already
 from errbot.utils import mess_2_embeddablehtml
@@ -208,7 +207,7 @@ class GraphicBackend(TextBackend):
     def __init__(self, config):
         self.conn = None
         super().__init__(config)
-        self.jid = SimpleIdentifier('Err')
+        self.jid = build_identifier('Err')
         self.app = None
 
     def send_command(self, text):
@@ -224,9 +223,6 @@ class GraphicBackend(TextBackend):
         msg = Message(txt, html=node) if node else Message(txt)
         msg.frm = self.jid
         return msg  # rebuild a pure html snippet to include directly in the console html
-
-    def build_identifier(self, strrep):
-        return SimpleIdentifier(strrep)
 
     def serve_forever(self):
         self.connect()  # be sure we are "connected" before the first command

--- a/errbot/backends/graphic.py
+++ b/errbot/backends/graphic.py
@@ -6,6 +6,7 @@ import sys
 import errbot
 from errbot.backends.base import Message, build_text_html_message_pair, Identifier
 from errbot.backed.text import TextBackend   # we use that as we emulate MUC there already
+from errbot.backends.text import SimpleIdentifier
 from errbot.utils import mess_2_embeddablehtml
 
 log = logging.getLogger(__name__)
@@ -223,6 +224,9 @@ class GraphicBackend(TextBackend):
         msg = Message(txt, html=node) if node else Message(txt)
         msg.frm = self.jid
         return msg  # rebuild a pure html snippet to include directly in the console html
+
+    def build_identifier(self, strrep):
+        return SimpleIdentifier(strrep)
 
     def serve_forever(self):
         self.connect()  # be sure we are "connected" before the first command

--- a/errbot/backends/graphic.py
+++ b/errbot/backends/graphic.py
@@ -4,8 +4,8 @@ import re
 import sys
 
 import errbot
-from errbot.backends.base import Message, build_text_html_message_pair, Identifier
-from errbot.backed.text import TextBackend   # we use that as we emulate MUC there already
+from errbot.backends.base import Message, build_text_html_message_pair
+from errbot.backends.text import TextBackend   # we use that as we emulate MUC there already
 from errbot.backends.text import SimpleIdentifier
 from errbot.utils import mess_2_embeddablehtml
 
@@ -208,7 +208,7 @@ class GraphicBackend(TextBackend):
     def __init__(self, config):
         self.conn = None
         super().__init__(config)
-        self.jid = Identifier('Err')
+        self.jid = SimpleIdentifier('Err')
         self.app = None
 
     def send_command(self, text):

--- a/errbot/backends/graphic.py
+++ b/errbot/backends/graphic.py
@@ -4,9 +4,9 @@ import re
 import sys
 
 import errbot
+from errbot.backends import SimpleIdentifier
 from errbot.backends.base import Message, build_text_html_message_pair
 from errbot.backends.text import TextBackend   # we use that as we emulate MUC there already
-from errbot.backends.text import SimpleIdentifier
 from errbot.utils import mess_2_embeddablehtml
 
 log = logging.getLogger(__name__)

--- a/errbot/backends/graphic.py
+++ b/errbot/backends/graphic.py
@@ -24,7 +24,9 @@ except ImportError:
     sudo apt-get install python-pyside
     -> On Gentoo
     sudo emerge -av dev-python/pyside
-    -> Generic
+    -> On Arch
+    sudo pacman -S python-pyside
+     -> Generic/virtual envs
     pip install PySide
     """)
     sys.exit(-1)
@@ -108,18 +110,6 @@ class CommandBox(QtGui.QPlainTextEdit, object):
         super(CommandBox, self).keyPressEvent(*args, **kwargs)
 
 
-class ConnectionMock(QObject):
-    newAnswer = QtCore.Signal(str, bool)
-
-    def send_message(self, mess):
-        self.send(mess)
-
-    def send(self, mess):
-        if hasattr(mess, 'body') and mess.body and not mess.body.isspace():
-            content, is_html = mess_2_embeddablehtml(mess)
-            self.newAnswer.emit(content, is_html)
-
-
 urlfinder = re.compile(r'http([^\.\s]+\.[^\.\s]*)+[^\.\s]{2,}')
 
 
@@ -159,6 +149,8 @@ background-size: contain; margin:0;">"""
 
 
 class ChatApplication(QtGui.QApplication):
+    newAnswer = QtCore.Signal(str, bool)
+
     def __init__(self, *args, **kwargs):
         backend = kwargs.pop('backend')
         config = kwargs.pop('config')
@@ -191,7 +183,7 @@ class ChatApplication(QtGui.QApplication):
         self.output.page().mainFrame().contentsSizeChanged.connect(self.scroll_output_to_bottom)
         self.output.page().linkClicked.connect(QtGui.QDesktopServices.openUrl)
         self.input.newCommand.connect(lambda text: backend.send_command(text))
-        backend.conn.newAnswer.connect(self.new_message)
+        self.newAnswer.connect(self.new_message)
 
         self.mainW.show()
 
@@ -205,15 +197,14 @@ class ChatApplication(QtGui.QApplication):
 
 class GraphicBackend(TextBackend):
     def __init__(self, config):
-        self.conn = None
         super().__init__(config)
-        self.jid = build_identifier('Err')
+        self.jid = self.build_identifier('Err')
         self.app = None
 
     def send_command(self, text):
         self.app.new_message(text, False)
         msg = Message(text)
-        msg.frm = self.bot_config.BOT_ADMINS[0]  # assume this is the admin talking
+        msg.frm = self.build_identifier(self.bot_config.BOT_ADMINS[0])  # assume this is the admin talking
         msg.to = self.jid  # To me only
         self.callback_message(msg)
         self.app.input.clear()
@@ -224,8 +215,16 @@ class GraphicBackend(TextBackend):
         msg.frm = self.jid
         return msg  # rebuild a pure html snippet to include directly in the console html
 
+
+    def send_message(self, mess):
+        self.send(mess)
+
+    def send(self, mess):
+        if hasattr(mess, 'body') and mess.body and not mess.body.isspace():
+            content, is_html = mess_2_embeddablehtml(mess)
+            self.app.newAnswer.emit(content, is_html)
+
     def serve_forever(self):
-        self.connect()  # be sure we are "connected" before the first command
         self.connect_callback()  # notify that the connection occured
 
         # create window and components
@@ -236,11 +235,6 @@ class GraphicBackend(TextBackend):
             self.disconnect_callback()
             self.shutdown()
             exit(0)
-
-    def connect(self):
-        if not self.conn:
-            self.conn = ConnectionMock()
-        return self.conn
 
     @property
     def mode(self):

--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -3,7 +3,6 @@ import sys
 
 from errbot.backends.base import MUCOccupant, MUCRoom, RoomDoesNotExistError
 from errbot.backends.xmpp import XMPPBackend, XMPPConnection
-from errbot.utils import parse_jid
 
 log = logging.getLogger(__name__)
 
@@ -86,15 +85,15 @@ class HipChatMUCRoom(MUCRoom):
 
     @property
     def node(self):
-        return parse_jid(self.jid)[0]
+        return self._bot.build_identifier(self.jid).node
 
     @property
     def domain(self):
-        return parse_jid(self.jid)[1]
+        return self._bot.build_identifier(self.jid).domain
 
     @property
     def resource(self):
-        return parse_jid(self.jid)[2]
+        return self._bot.build_identifier(self.jid).resource
 
     def __repr__(self):
         return "<HipChatMUCRoom('{}')>".format(self.name)

--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -1,8 +1,8 @@
 import logging
 import sys
 
-from errbot.backends.base import MUCOccupant, MUCRoom, RoomDoesNotExistError
-from errbot.backends.xmpp import XMPPBackend, XMPPConnection
+from errbot.backends.base import RoomDoesNotExistError
+from errbot.backends.xmpp import XMPPMUCOccupant, XMPPMUCRoom, XMPPBackend, XMPPConnection
 
 log = logging.getLogger(__name__)
 
@@ -18,7 +18,7 @@ except ImportError:
     sys.exit(1)
 
 
-class HipChatMUCOccupant(MUCOccupant):
+class HipChatMUCOccupant(XMPPMUCOccupant):
     """
     An occupant of a Multi-User Chatroom.
 
@@ -41,7 +41,7 @@ class HipChatMUCOccupant(MUCOccupant):
         return self.name
 
 
-class HipChatMUCRoom(MUCRoom):
+class HipChatMUCRoom(XMPPMUCRoom):
     """
     This class represents a Multi-User Chatroom.
     """

--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -4,7 +4,7 @@ import sys
 import warnings
 
 from errbot.backends.base import (
-    Identifier, Message, MUCOccupant, MUCRoom, RoomError, RoomNotJoinedError,
+    Message, MUCOccupant, MUCRoom, RoomError, RoomNotJoinedError,
     build_message, build_text_html_message_pair,
 )
 from errbot.errBot import ErrBot
@@ -212,7 +212,7 @@ class IRCConnection(SingleServerIRCBot):
 
     def on_pubmsg(self, _, e):
         msg = Message(e.arguments[0], type_='groupchat')
-        msg.frm = Identifier(node=e.target)
+        msg.frm = self.callback.build_identifier(e.target)
         msg.to = self.callback.jid
         msg.nick = e.source.split('!')[0]  # FIXME find the real nick in the channel
         self.callback.callback_message(msg)

--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -30,9 +30,11 @@ except ImportError as _:
     """)
     sys.exit(-1)
 
-class IRCIdentifier(Identifier):
-    def __init__(self, s):
-        self._nick, self._domain = s.split('!')
+
+class IRCIdentifier(object):
+    def __init__(self, nick, domain):
+        self._nick = nick
+        self._domain = domain
 
     @property
     def nick(self):
@@ -42,7 +44,9 @@ class IRCIdentifier(Identifier):
     def domain(self):
         return self._domain
 
-    # TODO: __unicode__
+    def __unicode__(self):
+        return "{}!{}" % (self._nick, self._domain)
+
 
 class IRCMUCRoom(MUCRoom):
     def __init__(self, *args, **kwargs):
@@ -270,6 +274,10 @@ class IRCBackend(ErrBot):
 
     def build_message(self, text):
         return build_message(text, Message)
+
+    def build_identifier(self, txtrep):
+        nick, domain = txtrep.split('!')
+        return IRCIdentifier(nick, domain)
 
     def shutdown(self):
         super().shutdown()

--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -73,7 +73,6 @@ class IRCMUCOccupant(IRCIdentifier):
         return self.__unicode__()
 
 
-
 class IRCMUCRoom(MUCRoom):
     def __init__(self, room, bot):
         self._bot = bot
@@ -239,7 +238,7 @@ class IRCConnection(SingleServerIRCBot):
         nick = e.source.split('!')[0]
         room = e.target
         if room[0] != '#' and room[0] != '$':
-           raise Exception('[%s] is not a room' % room)
+            raise Exception('[%s] is not a room' % room)
         msg.frm = IRCMUCOccupant(nick, room)
         msg.to = self.callback.jid
         msg.nick = nick  # FIXME find the real nick in the channel

--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -30,6 +30,19 @@ except ImportError as _:
     """)
     sys.exit(-1)
 
+class IRCIdentifier(Identifier):
+    def __init__(self, s):
+        self._nick, self._domain = s.split('!')
+
+    @property
+    def nick(self):
+        return self._nick
+
+    @property
+    def domain(self):
+        return self._domain
+
+    # TODO: __unicode__
 
 class IRCMUCRoom(MUCRoom):
     def __init__(self, *args, **kwargs):

--- a/errbot/backends/null.py
+++ b/errbot/backends/null.py
@@ -1,6 +1,6 @@
 import logging
 from time import sleep
-from errbot.backends.base import Message, Identifier, build_text_html_message_pair
+from errbot.backends.base import Message, build_text_html_message_pair
 from errbot.backends.text import SimpleIdentifier
 from errbot.errBot import ErrBot
 
@@ -21,7 +21,7 @@ class NullBackend(ErrBot):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.jid = Identifier('Err')  # whatever
+        self.jid = SimpleIdentifier('Err')  # whatever
 
     def serve_forever(self):
         self.connect()  # be sure we are "connected" before the first command

--- a/errbot/backends/null.py
+++ b/errbot/backends/null.py
@@ -1,7 +1,7 @@
 import logging
 from time import sleep
 from errbot.backends.base import Message, build_text_html_message_pair
-from errbot.backends.text import SimpleIdentifier
+from errbot.backends import SimpleIdentifier
 from errbot.errBot import ErrBot
 
 log = logging.getLogger(__name__)

--- a/errbot/backends/null.py
+++ b/errbot/backends/null.py
@@ -1,6 +1,7 @@
 import logging
 from time import sleep
 from errbot.backends.base import Message, Identifier, build_text_html_message_pair
+from errbot.backends.text import SimpleIdentifier
 from errbot.errBot import ErrBot
 
 log = logging.getLogger(__name__)
@@ -46,7 +47,10 @@ class NullBackend(ErrBot):
 
     def build_message(self, text):
         text, html = build_text_html_message_pair(text)
-        return Message(text, html=html)
+        return Message(text, html=html)se
+
+    def build_identifier(self, strrep):
+        return SimpleIdentifier(strrep)
 
     def join_room(self, room, username=None, password=None):
         pass  # just ignore that

--- a/errbot/backends/null.py
+++ b/errbot/backends/null.py
@@ -47,7 +47,7 @@ class NullBackend(ErrBot):
 
     def build_message(self, text):
         text, html = build_text_html_message_pair(text)
-        return Message(text, html=html)se
+        return Message(text, html=html)
 
     def build_identifier(self, strrep):
         return SimpleIdentifier(strrep)

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -248,8 +248,8 @@ class SlackBackend(ErrBot):
         else:
             msg.frm = SlackMUCOccupant(self.sc, event['user'], event['channel'])
             msg.to = SlackMUCOccupant(self.sc, self.username_to_userid(self.sc.server.username),
-                                     event['channel'])
- 
+                                      event['channel'])
+
         msg.nick = msg.frm.userid
         self.callback_message(msg)
 

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -5,7 +5,7 @@ import time
 import sys
 from errbot import PY3
 from errbot.backends.base import (
-    Message, build_message, Identifier, Presence, ONLINE, AWAY,
+    Message, build_message, Presence, ONLINE, AWAY,
     MUCRoom, RoomDoesNotExistError, UserDoesNotExistError
 )
 from errbot.errBot import ErrBot

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -53,7 +53,7 @@ class SlackAPIResponseError(RuntimeError):
 
 
 class SlackIdentifier(Identifier):
-    def __init__(self, userid, domain, channel = None):
+    def __init__(self, userid, domain, channel=None):
         self._userid = userid
         self._domain = domain
         self._channel = channel
@@ -70,17 +70,14 @@ class SlackIdentifier(Identifier):
     def channel(self):
         return self._channel
 
+    def __unicode__(self):
+        # TODO if domain
+        return "{}@{}" % (self._userid, self._domain)
+
 
 class SlackMUCOccupant(SlackIdentifier):
     """
     This class represents a person inside a MUC.
-
-    This class exists to expose additional information about occupants
-    inside a MUC. For example, the XMPP back-end may expose backend-specific
-    information such as the real JID of the occupant and whether or not
-    that person is a moderator or owner of the room.
-
-    See the parent class for additional details.
     """
 
 
@@ -206,8 +203,12 @@ class SlackBackend(ErrBot):
             return
 
         msg = Message(event['text'], type_=message_type)
-        msg.frm = SlackIdentifier(self.userid_to_username(event['user']), self.sc.server.domain, self.channelid_to_channelname(event['channel']))
-        msg.to = SlackIdentifier(self.sc.server.username, self.sc.server.domain, self.channelid_to_channelname(event['channel']))
+        msg.frm = SlackIdentifier(self.userid_to_username(event['user']),
+                                  self.sc.server.domain,
+                                  self.channelid_to_channelname(event['channel']))
+        msg.to = SlackIdentifier(self.sc.server.username,
+                                 self.sc.server.domain,
+                                 self.channelid_to_channelname(event['channel']))
         msg.nick = msg.frm.userid
         self.callback_message(msg)
 
@@ -295,6 +296,10 @@ class SlackBackend(ErrBot):
 
     def build_message(self, text):
         return build_message(text, Message)
+
+    def build_identifier(self, txtrep):
+        # TODO channel
+        return SlackIdentifier(txtrep, self.sc.server.domain)
 
     def build_reply(self, mess, text=None, private=False):
         msg_type = mess.type

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -144,8 +144,8 @@ class TestMUCRoom(MUCRoom):
 class TestBackend(ErrBot):
     def __init__(self, config):
         super().__init__(config)
-        self.jid = SimpleIdentifier('Err')  # whatever
-        self.sender = SimpleIdentifier(config.BOT_ADMINS[0])  # By default, assume this is the admin talking
+        self.jid = self.build_identifier('Err')  # whatever
+        self.sender = self.build_identifier(config.BOT_ADMINS[0])  # By default, assume this is the admin talking
 
     def send_message(self, mess):
         super(TestBackend, self).send_message(mess)
@@ -189,22 +189,21 @@ class TestBackend(ErrBot):
     def build_message(self, text):
         return build_message(text, Message)
 
+    def build_identifier(self, text_representation):
+        return SimpleIdentifier(text_representation)
+
     def build_reply(self, mess, text=None, private=False):
         msg = self.build_message(text)
         msg.frm = self.jid
         msg.to = mess.frm
         return msg
 
-    def shutdown(self):
-        super(TestBackend, self).shutdown()
-
     @property
     def mode(self):
-        return 'text'
+        return 'test'
 
     def rooms(self):
         global rooms
-        log.debug('******************** ROOMS %s' % repr(rooms))
         return [r for r in rooms if r.joined]
 
     def query_room(self, room):

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -101,7 +101,7 @@ class TestMUCRoom(MUCRoom):
             return
 
         room = [r for r in rooms if r._name == self._name][0]
-        room._occupants = [o for o in room._occupants if o != bot_itself]
+        room._occupants.remove(bot_itself)
         log.info("Left room {!s}".format(self))
         self._bot.callback_room_left(room)
 

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -64,9 +64,16 @@ class TestMUCRoom(MUCRoom):
     def joined(self):
         global rooms
         bot_itself = SimpleMUCOccupant(config.BOT_IDENTITY['username'])
+        log.info("rooms = %s" % repr(rooms))
+        log.info("self = %s" % repr(self))
+        log.info("bot_itself = %s" % repr(bot_itself))
         room = [r for r in rooms if r._name == self._name]
         if room:
-            return bot_itself in room[0].occupants
+            # bot_itself in room[0].occupants doesn't work on py2.7
+            for occupant in room[0].occupants:
+                if bot_itself.__eq__(occupant):
+                    return True
+            return False
         else:
             return False
 

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -7,6 +7,7 @@ from tempfile import mkdtemp
 from threading import Thread
 
 import pytest
+from errbot.backends.text import SimpleIdentifier
 
 log = logging.getLogger(__name__)
 
@@ -24,7 +25,7 @@ config.BOT_LOG_LEVEL = logging.DEBUG
 # Errbot machinery must not be imported before this point
 # because of the import hackery above.
 from errbot.backends.base import (
-    Message, build_message, Identifier, MUCRoom, MUCOccupant  # noqa
+    Message, build_message, MUCRoom, MUCOccupant  # noqa
 )
 from errbot.core_plugins.wsview import reset_app  # noqa
 from errbot.errBot import ErrBot  # noqa
@@ -140,7 +141,7 @@ class MUCRoom(MUCRoom):
 class TestBackend(ErrBot):
     def __init__(self, config):
         super().__init__(config)
-        self.jid = Identifier('Err')  # whatever
+        self.jid = SimpleIdentifier('Err')  # whatever
         self.sender = config.BOT_ADMINS[0]  # By default, assume this is the admin talking
 
     def send_message(self, mess):

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -140,6 +140,7 @@ class TestMUCRoom(MUCRoom):
     def __str__(self):
         return self._name
 
+
 class TestBackend(ErrBot):
     def __init__(self, config):
         super().__init__(config)

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -53,7 +53,7 @@ class TestMUCRoom(MUCRoom):
             occupants = []
         self._occupants = occupants
         self._topic = topic
-        super(MUCRoom, self).__init__(jid=jid, node=node, domain=domain, resource=resource, bot=bot)
+        self._bot = bot
 
     @property
     def occupants(self):
@@ -139,7 +139,7 @@ class TestBackend(ErrBot):
     def __init__(self, config):
         super().__init__(config)
         self.jid = SimpleIdentifier('Err')  # whatever
-        self.sender = config.BOT_ADMINS[0]  # By default, assume this is the admin talking
+        self.sender = SimpleIdentifier(config.BOT_ADMINS[0])  # By default, assume this is the admin talking
 
     def send_message(self, mess):
         super(TestBackend, self).send_message(mess)
@@ -183,6 +183,12 @@ class TestBackend(ErrBot):
     def build_message(self, text):
         return build_message(text, Message)
 
+    def build_reply(self, mess, text=None, private=False):
+        msg = Message(text)
+        msg.frm = self.jid
+        msg.to = mess.frm
+        return msg
+
     def shutdown(self):
         super(TestBackend, self).shutdown()
 
@@ -199,7 +205,7 @@ class TestBackend(ErrBot):
         try:
             return [r for r in rooms if str(r) == str(room)][0]
         except IndexError:
-            r = MUCRoom(jid=room, bot=self)
+            r = TestMUCRoom(room, bot=self)
             return r
 
     def groupchat_reply_format(self):

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -64,7 +64,7 @@ class TestMUCRoom(MUCRoom):
     def joined(self):
         global rooms
         bot_itself = SimpleMUCOccupant(config.BOT_IDENTITY['username'])
-        room = [r for r in rooms if str(r) == str(self)]
+        room = [r for r in rooms if r._name == self._name]
         if room:
             return bot_itself in room[0].occupants
         else:
@@ -82,7 +82,7 @@ class TestMUCRoom(MUCRoom):
             log.debug("Room {!s} doesn't exist yet, creating it".format(self))
             self.create()
 
-        room = [r for r in rooms if str(r) == str(self)][0]
+        room = [r for r in rooms if r._name == self._name][0]
         room._occupants.append(SimpleMUCOccupant(bot_itself))
         log.info("Joined room {!s}".format(self))
         self._bot.callback_room_joined(room)
@@ -95,7 +95,7 @@ class TestMUCRoom(MUCRoom):
             logging.warning("Attempted to leave room '{!s}', but not in this room".format(self))
             return
 
-        room = [r for r in rooms if str(r) == str(self)][0]
+        room = [r for r in rooms if r._name == self._name][0]
         room._occupants = [o for o in room._occupants if o != bot_itself]
         log.info("Left room {!s}".format(self))
         self._bot.callback_room_left(room)
@@ -103,7 +103,7 @@ class TestMUCRoom(MUCRoom):
     @property
     def exists(self):
         global rooms
-        return str(self) in [str(r) for r in rooms]
+        return self._name in [r._name for r in rooms]
 
     def create(self):
         global rooms
@@ -118,7 +118,7 @@ class TestMUCRoom(MUCRoom):
         if not self.exists:
             logging.warning("Cannot destroy room {!s}, it doesn't exist".format(self))
         else:
-            rooms = [r for r in rooms if str(r) != str(self)]
+            rooms = [r for r in rooms if r._name != self._name]
             log.info("Destroyed room {!s}".format(self))
 
     @property
@@ -129,7 +129,7 @@ class TestMUCRoom(MUCRoom):
     def topic(self, topic):
         global rooms
         self._topic = topic
-        room = [r for r in rooms if str(r) == str(self)][0]
+        room = [r for r in rooms if r._name == self._name][0]
         room._topic = self._topic
         log.info("Topic for room {!s} set to '{}'".format(self, topic))
         self._bot.callback_room_topic(self)

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -7,7 +7,7 @@ from tempfile import mkdtemp
 from threading import Thread
 
 import pytest
-from errbot.backends.text import SimpleIdentifier
+from errbot.backends import SimpleIdentifier, SimpleMUCOccupant
 
 log = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ config.BOT_LOG_LEVEL = logging.DEBUG
 # Errbot machinery must not be imported before this point
 # because of the import hackery above.
 from errbot.backends.base import (
-    Message, build_message, MUCRoom, MUCOccupant  # noqa
+    Message, build_message, MUCRoom  # noqa
 )
 from errbot.core_plugins.wsview import reset_app  # noqa
 from errbot.errBot import ErrBot  # noqa
@@ -42,13 +42,10 @@ STZ_PRE = 2
 STZ_IQ = 3
 
 
-class MUCRoom(MUCRoom):
-    def __init__(self, jid=None, node='', domain='', resource='', occupants=None, topic=None, bot=None):
+class TestMUCRoom(MUCRoom):
+    def __init__(self, name, occupants=None, topic=None, bot=None):
         """
-        :param jid: See parent class.
-        :param node: See parent class.
-        :param domain: See parent class.
-        :param resource: See parent class.
+        :param name: Name of the room
         :param occupants: Occupants of the room
         :param topic: The MUC's topic
         """
@@ -86,7 +83,7 @@ class MUCRoom(MUCRoom):
             self.create()
 
         room = [r for r in rooms if str(r) == str(self)][0]
-        room._occupants.append(MUCOccupant(bot_itself))
+        room._occupants.append(SimpleMUCOccupant(bot_itself))
         log.info("Joined room {!s}".format(self))
         self._bot.callback_room_joined(room)
 

--- a/errbot/backends/text.py
+++ b/errbot/backends/text.py
@@ -11,6 +11,13 @@ A_RESET = '\x1b[0m'
 A_CYAN = '\x1b[36m'
 A_BLUE = '\x1b[34m'
 
+class SimpleIdentifier(Identifier):
+    def __init__(self, s):
+        self._nick = s
+
+    @property
+    def nick(self):
+        return self._nick
 
 class TextBackend(ErrBot):
 

--- a/errbot/backends/text.py
+++ b/errbot/backends/text.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from errbot.backends import SimpleIdentifier
 from errbot.backends.base import Message, build_message, Presence, ONLINE, OFFLINE, MUCRoom
 from errbot.errBot import ErrBot
 from errbot.utils import deprecated
@@ -10,15 +11,6 @@ ANSI = hasattr(sys.stderr, 'isatty') and sys.stderr.isatty()
 A_RESET = '\x1b[0m'
 A_CYAN = '\x1b[36m'
 A_BLUE = '\x1b[34m'
-
-
-class SimpleIdentifier(str):
-    """ This is a test identifier just represented as a string """
-    @property
-    def person(self):
-        """This needs to return the part of the identifier pointing to a person.
-        For example for XMPP it is node@domain without the resource that actually maps to a device."""
-        return self
 
 
 class TextBackend(ErrBot):

--- a/errbot/backends/text.py
+++ b/errbot/backends/text.py
@@ -11,24 +11,21 @@ A_RESET = '\x1b[0m'
 A_CYAN = '\x1b[36m'
 A_BLUE = '\x1b[34m'
 
-class SimpleIdentifier(Identifier):
-    def __init__(self, s):
-        self._nick = s
 
-    @property
-    def nick(self):
-        return self._nick
+class SimpleIdentifier(str):
+    """ This is a test identifier just represented as a string """
+
 
 class TextBackend(ErrBot):
 
     def __init__(self, config):
         super().__init__(config)
         log.debug("Text Backend Init.")
-        self.jid = Identifier('Err')
+        self.jid = SimpleIdentifier('Err')
         self.rooms = set()
 
     def serve_forever(self):
-        me = Identifier(self.bot_config.BOT_ADMINS[0])
+        me = SimpleIdentifier(self.bot_config.BOT_ADMINS[0])
         self.connect_callback()  # notify that the connection occured
         self.callback_presence(Presence(identifier=me, status=ONLINE))
         try:

--- a/errbot/backends/text.py
+++ b/errbot/backends/text.py
@@ -18,11 +18,11 @@ class TextBackend(ErrBot):
     def __init__(self, config):
         super().__init__(config)
         log.debug("Text Backend Init.")
-        self.jid = SimpleIdentifier('Err')
+        self.jid = self.build_identifier('Err')
         self.rooms = set()
 
     def serve_forever(self):
-        me = SimpleIdentifier(self.bot_config.BOT_ADMINS[0])
+        me = self.build_identifier(self.bot_config.BOT_ADMINS[0])
         self.connect_callback()  # notify that the connection occured
         self.callback_presence(Presence(identifier=me, status=ONLINE))
         try:
@@ -56,6 +56,9 @@ class TextBackend(ErrBot):
 
     def build_message(self, text):
         return build_message(text, Message)
+
+    def build_identifier(self, text_representation):
+        return SimpleIdentifier(text_representation)
 
     def build_reply(self, mess, text=None, private=False):
         response = self.build_message(text)
@@ -122,7 +125,7 @@ class TextMUCRoom(MUCRoom):
 
     @property
     def occupants(self):
-        return [SimpleIdentifier("Somebody")]
+        return [self.build_identifier("Somebody")]
 
     def invite(self, *args):
         pass

--- a/errbot/backends/tox.py
+++ b/errbot/backends/tox.py
@@ -7,7 +7,7 @@ from os.path import exists, join
 import io
 from errbot.backends import base
 from errbot.errBot import ErrBot
-from errbot.backends.base import Message, Identifier, Presence, Stream, MUCRoom
+from errbot.backends.base import Message, Presence, Stream, MUCRoom
 from errbot.backends.base import ONLINE, OFFLINE, AWAY, DND
 from errbot.backends.base import build_message
 from errbot.backends.base import STREAM_TRANSFER_IN_PROGRESS
@@ -48,12 +48,14 @@ TOX_GROUP_TO_ERR_STATUS = {
     Tox.CHAT_CHANGE_PEER_NAME: None,
 }
 
-class ToxIdentifier(Identifier):
+
+class ToxIdentifier(object):
     def __init__(self, client_id=None, group_number=None, friend_group_number=None, username=None):
         self._client_id = client_id
         self._group_number = group_number
         self._friend_group_number = friend_group_number
         self._username = username
+
 
 class ToxStreamer(io.BufferedRWPair):
     def __init__(self):
@@ -81,7 +83,7 @@ class ToxConnection(Tox):
         self.bootstrap_from_address(*bootstrap_servers)
 
     def friend_to_idd(self, friend_number):
-        return Identifier(self.get_client_id(friend_number))
+        return ToxIdentifier(client_id=self.get_client_id(friend_number))
 
     def idd_to_friend(self, identifier, autoinvite=True, autoinvite_message='I am just a bot.'):
         """

--- a/errbot/backends/tox.py
+++ b/errbot/backends/tox.py
@@ -31,9 +31,9 @@ TOX_MAX_MESS_LENGTH = 1368
 NOT_ADMIN = "You are not recognized as an administrator of this bot"
 
 TOX_TO_ERR_STATUS = {
-    Tox.USERSTATUS_NONE: ONLINE,
-    Tox.USERSTATUS_AWAY: AWAY,
-    Tox.USERSTATUS_BUSY: DND,
+    Tox.USER_STATUS_NONE: ONLINE,
+    Tox.USER_STATUS_AWAY: AWAY,
+    Tox.USER_STATUS_BUSY: DND,
 }
 
 TOX_GROUP_TO_ERR_STATUS = {
@@ -49,6 +49,11 @@ class ToxIdentifier(object):
         self._group_number = group_number
         self._friend_group_number = friend_group_number
         self._username = username
+
+    @property
+    def person(self):
+        return self._username
+
 
 
 class ToxStreamer(io.BufferedRWPair):

--- a/errbot/backends/tox.py
+++ b/errbot/backends/tox.py
@@ -55,7 +55,6 @@ class ToxIdentifier(object):
         return self._username
 
 
-
 class ToxStreamer(io.BufferedRWPair):
     def __init__(self):
         r, w = os.pipe()

--- a/errbot/backends/tox.py
+++ b/errbot/backends/tox.py
@@ -26,12 +26,6 @@ except ImportError:
     sys.exit(-1)
 
 
-# Backend notes
-#
-# TOX mapping to Err Identifier :
-# TOX client_id as hash string -> node
-
-
 TOX_MAX_MESS_LENGTH = 1368
 
 NOT_ADMIN = "You are not recognized as an administrator of this bot"
@@ -90,7 +84,7 @@ class ToxConnection(Tox):
         Returns the Tox friend number from the roster.
 
         :exception ValueError if the identifier is not a Tox one.
-        :param identifier: an err Identifier
+        :param identifier: an err identifier
         :param autoinvite: set to True if you want to invite this identifier if it is not in your roster.
         :return: the tox friend number from the roster, None if it could not be found.
         """

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -556,7 +556,6 @@ class XMPPBackend(ErrBot):
 
         return XMPPIdentifier(node, domain, resource)
 
-
     def build_reply(self, mess, text=None, private=False):
         """Build a message for responding to another message.
         Message is NOT sent"""

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -3,9 +3,7 @@ import sys
 import warnings
 
 from errbot.backends.base import (
-    Message, MUCRoom, MUCOccupant, Presence, RoomNotJoinedError,
-    build_message,
-    Identifier)
+    Message, MUCRoom, MUCOccupant, Presence, RoomNotJoinedError, build_message)
 from errbot.backends.base import ONLINE, OFFLINE, AWAY, DND
 from errbot.errBot import ErrBot
 from threading import Thread
@@ -59,7 +57,8 @@ def verify_gtalk_cert(xmpp_client):
 
     log.error("invalid cert received for %s", xmpp_client.boundjid.server)
 
-class XMPPIdentifier(Identifier):
+
+class XMPPIdentifier(object):
     """
     This class is the parent and the basic contract of all the ways the backends
     are identifying a person on their system.

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -8,7 +8,6 @@ from errbot.backends.base import ONLINE, OFFLINE, AWAY, DND
 from errbot.errBot import ErrBot
 from threading import Thread
 from time import sleep
-from errbot.utils import parse_jid
 
 log = logging.getLogger(__name__)
 
@@ -64,13 +63,10 @@ class XMPPIdentifier(object):
     are identifying a person on their system.
     """
 
-    def __init__(self, jid=None, node='', domain='', resource=''):
-        if jid:
-            self._node, self._domain, self._resource = parse_jid(jid)
-        else:
-            self._node = node
-            self._domain = domain
-            self._resource = resource
+    def __init__(self, node='', domain='', resource=''):
+        self._node = node
+        self._domain = domain
+        self._resource = resource
 
     @property
     def node(self):
@@ -544,6 +540,22 @@ class XMPPBackend(ErrBot):
 
     def build_message(self, text):
         return build_message(text, Message)
+
+    def build_identifier(self, txtrep):
+        if jid.find('@') != -1:
+            split_jid = jid.split('@')
+            node, domain = '@'.join(split_jid[:-1]), split_jid[-1]
+            if domain.find('/') != -1:
+                domain, resource = domain.split('/')[0:2]  # hack for IRC where you can have several slashes here
+            else:
+                resource = None
+        else:
+            node = jid
+            domain = None
+            resource = None
+
+        return XMPPIdentifier(node, domain, resource)
+
 
     def build_reply(self, mess, text=None, private=False):
         """Build a message for responding to another message.

--- a/errbot/core_plugins/chatRoom.py
+++ b/errbot/core_plugins/chatRoom.py
@@ -193,7 +193,7 @@ class ChatRoom(BotPlugin):
             return
         for room in args:
             try:
-                occupants = [str(o) for o in self.query_room(room).occupants]
+                occupants = [o.person for o in self.query_room(room).occupants]
                 yield "Occupants in {}:\n\t{}".format(room, "\n\t".join(occupants))
             except RoomNotJoinedError as e:
                 yield "Cannot list occupants in {}: {}".format(room, e)

--- a/errbot/core_plugins/chatRoom.py
+++ b/errbot/core_plugins/chatRoom.py
@@ -253,7 +253,7 @@ class ChatRoom(BotPlugin):
             try:
                 mess_type = mess.type
                 if mess_type == 'chat':
-                    username = mess.frm.node
+                    username = mess.frm.person
                     if username in self.bot_config.CHATROOM_RELAY:
                         log.debug('Message to relay from %s.' % username)
                         body = mess.body
@@ -262,6 +262,7 @@ class ChatRoom(BotPlugin):
                             self.send(room, body, message_type='groupchat')
                 elif mess_type == 'groupchat':
                     fr = mess.frm
+                    # TODO fixme for non XMPP backend
                     chat_room = fr.node + '@' + fr.domain if fr.domain else fr.node
                     if chat_room in self.bot_config.REVERSE_CHATROOM_RELAY:
                         users_to_relay_to = self.bot_config.REVERSE_CHATROOM_RELAY[chat_room]

--- a/errbot/core_plugins/chatRoom.py
+++ b/errbot/core_plugins/chatRoom.py
@@ -27,6 +27,7 @@ class ChatRoom(BotPlugin):
         if not self.connected:
             self.connected = True
             for room in self.bot_config.CHATROOM_PRESENCE:
+                log.debug('Try to join room %s' % room)
                 if isinstance(room, basestring):
                     room, username, password = (room, self.bot_config.CHATROOM_FN, None)
                 else:

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -183,7 +183,6 @@ class ErrBot(Backend, StoreMixin, BotPluginManager):
         return errors
 
     def send_message(self, mess):
-        super(ErrBot, self).send_message(mess)
         for bot in self.get_all_active_plugin_objects():
             # noinspection PyBroadException
             try:

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -638,7 +638,7 @@ class ErrBot(Backend, StoreMixin, BotPluginManager):
     def history(self, mess, args):
         """display the command history"""
         answer = []
-        user_cmd_history = self.cmd_history[get_sender_username(mess)]
+        user_cmd_history = self.cmd_history[mess.frm.person]
         l = len(user_cmd_history)
         for i in range(0, l):
             c = user_cmd_history[i]

--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -17,6 +17,7 @@ PY2 = not PY3
 
 PLUGINS_SUBDIR = b'plugins' if PY2 else 'plugins'
 
+
 class deprecated(object):
     """ deprecated decorator. emits a warning on a call on an old method and call the new method anyway """
     def __init__(self, new=None):
@@ -55,6 +56,7 @@ class deprecated(object):
 def get_sender_username(mess):
     """Extract the sender's user name from a message"""
     return mess.frm.person
+
 
 def format_timedelta(timedelta):
     total_seconds = timedelta.seconds + (86400 * timedelta.days)

--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -249,22 +249,6 @@ def mess_2_embeddablehtml(mess):
         return mess.body, False
 
 
-def parse_jid(jid):
-    if jid.find('@') != -1:
-        split_jid = jid.split('@')
-        node, domain = '@'.join(split_jid[:-1]), split_jid[-1]
-        if domain.find('/') != -1:
-            domain, resource = domain.split('/')[0:2]  # hack for IRC where you can have several slashes here
-        else:
-            resource = None
-    else:
-        node = jid
-        domain = None
-        resource = None
-
-    return node, domain, resource
-
-
 def RateLimited(minInterval):
     def decorate(func):
         lastTimeCalled = [0.0]

--- a/tests/base_backend_tests.py
+++ b/tests/base_backend_tests.py
@@ -54,7 +54,7 @@ class DummyBackend(Backend):
         return build_message(text, Message)
 
     def build_reply(self, mess, text=None, private=False):
-        msg = Message(text)
+        msg = self.build_message(text)
         msg.frm = self.jid
         msg.to = mess.frm
         return msg
@@ -193,16 +193,15 @@ class TestExecuteAndSend(unittest.TestCase):
         m = self.example_message
 
         dummy._execute_and_send(cmd='return_args_as_str', args=['foo', 'bar'], match=None, mess=m,
-                                jid='noterr@localhost', template_name=dummy.return_args_as_str._err_command_template)
+                                template_name=dummy.return_args_as_str._err_command_template)
         self.assertEqual("foobar", dummy.pop_message().body)
 
-    @unittest.skip("html borken")
     def test_commands_can_return_html(self):
         dummy = self.dummy
         m = self.example_message
 
         dummy._execute_and_send(cmd='return_args_as_html', args=['foo', 'bar'], match=None, mess=m,
-                                jid='noterr@localhost', template_name=dummy.return_args_as_html._err_command_template)
+                                template_name=dummy.return_args_as_html._err_command_template)
         response = dummy.pop_message()
         self.assertEqual("foobar", response.body)
         self.assertEqual('<strong xmlns:ns0="http://jabber.org/protocol/xhtml-im">foo</strong>'
@@ -213,12 +212,11 @@ class TestExecuteAndSend(unittest.TestCase):
         dummy = self.dummy
         m = self.example_message
 
-        dummy._execute_and_send(cmd='raises_exception', args=[], match=None, mess=m, jid='noterr@localhost',
+        dummy._execute_and_send(cmd='raises_exception', args=[], match=None, mess=m,
                                 template_name=dummy.raises_exception._err_command_template)
         self.assertIn(dummy.MSG_ERROR_OCCURRED, dummy.pop_message().body)
 
         dummy._execute_and_send(cmd='yields_str_then_raises_exception', args=[], match=None, mess=m,
-                                jid='noterr@localhost',
                                 template_name=dummy.yields_str_then_raises_exception._err_command_template)
         self.assertEqual("foobar", dummy.pop_message().body)
         self.assertIn(dummy.MSG_ERROR_OCCURRED, dummy.pop_message().body)
@@ -228,17 +226,16 @@ class TestExecuteAndSend(unittest.TestCase):
         m = self.example_message
 
         dummy._execute_and_send(cmd='yield_args_as_str', args=['foo', 'bar'], match=None, mess=m,
-                                jid='noterr@localhost', template_name=dummy.yield_args_as_str._err_command_template)
+                                template_name=dummy.yield_args_as_str._err_command_template)
         self.assertEqual("foo", dummy.pop_message().body)
         self.assertEqual("bar", dummy.pop_message().body)
 
-    @unittest.skip("html borken")
     def test_commands_can_yield_html(self):
         dummy = self.dummy
         m = self.example_message
 
         dummy._execute_and_send(cmd='yield_args_as_html', args=['foo', 'bar'], match=None, mess=m,
-                                jid='noterr@localhost', template_name=dummy.yield_args_as_html._err_command_template)
+                                template_name=dummy.yield_args_as_html._err_command_template)
         response1 = dummy.pop_message()
         response2 = dummy.pop_message()
         self.assertEqual("foo", response1.body)
@@ -254,7 +251,7 @@ class TestExecuteAndSend(unittest.TestCase):
         self.dummy.bot_config.MESSAGE_SIZE_LIMIT = len(LONG_TEXT_STRING)
 
         dummy._execute_and_send(cmd='return_long_output', args=['foo', 'bar'], match=None, mess=m,
-                                jid='noterr@localhost', template_name=dummy.return_long_output._err_command_template)
+                                template_name=dummy.return_long_output._err_command_template)
         for i in range(3):  # return_long_output outputs a string that's 3x longer than the size limit
             self.assertEqual(LONG_TEXT_STRING, dummy.pop_message().body)
         self.assertRaises(Empty, dummy.pop_message, *[], **{'block': False})
@@ -265,7 +262,7 @@ class TestExecuteAndSend(unittest.TestCase):
         self.dummy.bot_config.MESSAGE_SIZE_LIMIT = len(LONG_TEXT_STRING)
 
         dummy._execute_and_send(cmd='yield_long_output', args=['foo', 'bar'], match=None, mess=m,
-                                jid='noterr@localhost', template_name=dummy.yield_long_output._err_command_template)
+                                template_name=dummy.yield_long_output._err_command_template)
         for i in range(6):  # yields_long_output yields 2 strings that are 3x longer than the size limit
             self.assertEqual(LONG_TEXT_STRING, dummy.pop_message().body)
         self.assertRaises(Empty, dummy.pop_message, *[], **{'block': False})

--- a/tests/base_backend_tests.py
+++ b/tests/base_backend_tests.py
@@ -311,11 +311,13 @@ class BotCmds(unittest.TestCase):
 
         # Groupchat should still require the prefix
         m.type = "groupchat"
-        m.frm = SimpleMUCOccupant("someone@room")
+        m.frm = SimpleMUCOccupant("someone", "room")
         self.dummy.callback_message(m)
         self.assertRaises(Empty, self.dummy.pop_message, *[], **{'block': False})
 
-        m = self.makemessage("!return_args_as_str one two", from_=SimpleMUCOccupant("someone@room"), type="groupchat")
+        m = self.makemessage("!return_args_as_str one two",
+                             from_=SimpleMUCOccupant("someone", "room"),
+                             type="groupchat")
         self.dummy.callback_message(m)
         self.assertEquals("one two", self.dummy.pop_message().body)
 
@@ -437,25 +439,25 @@ class BotCmds(unittest.TestCase):
                 expected_response="Regular command"
             ),
             dict(
-                message=self.makemessage("!command", type="groupchat", from_=SimpleMUCOccupant("someone@room")),
+                message=self.makemessage("!command", type="groupchat", from_=SimpleMUCOccupant("someone", "room")),
                 acl={'command': {'allowrooms': ('room',)}},
                 acl_default={},
                 expected_response="Regular command"
             ),
             dict(
-                message=self.makemessage("!command", type="groupchat", from_=SimpleMUCOccupant("someone@room")),
+                message=self.makemessage("!command", type="groupchat", from_=SimpleMUCOccupant("someone", "room")),
                 acl={'command': {'allowrooms': ('anotherroom@localhost',)}},
                 acl_default={},
                 expected_response="You're not allowed to access this command from this room",
             ),
             dict(
-                message=self.makemessage("!command", type="groupchat", from_=SimpleMUCOccupant("someone@room")),
+                message=self.makemessage("!command", type="groupchat", from_=SimpleMUCOccupant("someone", "room")),
                 acl={'command': {'denyrooms': ('room',)}},
                 acl_default={},
                 expected_response="You're not allowed to access this command from this room",
             ),
             dict(
-                message=self.makemessage("!command", type="groupchat", from_=SimpleMUCOccupant("someone@room")),
+                message=self.makemessage("!command", type="groupchat", from_=SimpleMUCOccupant("someone", "room")),
                 acl={'command': {'denyrooms': ('anotherroom',)}},
                 acl_default={},
                 expected_response="Regular command"

--- a/tests/base_backend_tests.py
+++ b/tests/base_backend_tests.py
@@ -20,7 +20,7 @@ import os  # noqa
 import re  # noqa
 from queue import Queue, Empty  # noqa
 from mock import patch  # noqa
-from errbot.backends.xmpp import XMPPIdentifier
+from errbot.backends import SimpleIdentifier  # noqa
 from errbot.backends.base import Backend, Message  # noqa
 from errbot.backends.base import build_message, build_text_html_message_pair  # noqa
 from errbot import botcmd, re_botcmd, arg_botcmd, templating  # noqa
@@ -38,7 +38,7 @@ class Config:
 
 class DummyBackend(Backend):
     outgoing_message_queue = Queue()
-    jid = XMPPIdentifier('err@localhost/err')
+    jid = SimpleIdentifier('err')
 
     def __init__(self, extra_config={}):
         self.bot_config = Config()
@@ -149,47 +149,12 @@ class TestBase(unittest.TestCase):
     def setUp(self):
         self.dummy = DummyBackend()
 
-    def test_identifier_parsing(self):
-        id1 = XMPPIdentifier(jid='gbin@gootz.net/toto')
-        self.assertEqual(id1.node, 'gbin')
-        self.assertEqual(id1.domain, 'gootz.net')
-        self.assertEqual(id1.resource, 'toto')
-
-        id2 = XMPPIdentifier(jid='gbin@gootz.net')
-        self.assertEqual(id2.node, 'gbin')
-        self.assertEqual(id2.domain, 'gootz.net')
-        self.assertIsNone(id2.resource)
-
-    def test_identifier_matching(self):
-        id1 = XMPPIdentifier(jid='gbin@gootz.net/toto')
-        id2 = XMPPIdentifier(jid='gbin@gootz.net/titi')
-        id3 = XMPPIdentifier(jid='gbin@giitz.net/titi')
-        self.assertTrue(id1.person == id2.person)
-        self.assertFalse(id2.person == id3.person)
-
-    def test_identifier_stripping(self):
-        id1 = XMPPIdentifier(jid='gbin@gootz.net/toto')
-        self.assertEqual(id1.stripped, 'gbin@gootz.net')
-
-    def test_identifier_str_rep(self):
-        self.assertEqual(str(XMPPIdentifier(jid="gbin@gootz.net/toto")), "gbin@gootz.net/toto")
-        self.assertEqual(str(XMPPIdentifier(jid="gbin@gootz.net")), "gbin@gootz.net")
-
-    def test_identifier_unicode_rep(self):
-        self.assertEqual(str(XMPPIdentifier(jid="gbin@gootz.net/へようこそ")), "gbin@gootz.net/へようこそ")
-
     def test_xhtmlparsing_and_textify(self):
         text_plain, node = build_text_html_message_pair('<html><body>Message</body></html>')
         self.assertEqual(text_plain, 'Message')
         self.assertEqual(node.tag, 'html')
         self.assertEqual(node.getchildren()[0].tag, 'body')
         self.assertEqual(node.getchildren()[0].text, 'Message')
-
-    def test_identifier_double_at_parsing(self):
-        id1 = XMPPIdentifier(jid='gbin@titi.net@gootz.net/toto')
-        self.assertEqual(id1.node, 'gbin@titi.net')
-        self.assertEqual(id1.domain, 'gootz.net')
-        self.assertEqual(id1.resource, 'toto')
 
     def test_buildreply(self):
         dummy = self.dummy
@@ -208,8 +173,8 @@ class TestExecuteAndSend(unittest.TestCase):
     def setUp(self):
         self.dummy = DummyBackend()
         self.example_message = self.dummy.build_message('some_message')
-        self.example_message.frm = 'noterr@localhost/resource'
-        self.example_message.to = 'err@localhost/resource'
+        self.example_message.frm = SimpleIdentifier('noterr@localhost/resource')
+        self.example_message.to = SimpleIdentifier('err@localhost/resource')
 
         assets_path = os.path.join(os.path.dirname(__file__), 'assets')
         templating.template_path.append(templating.make_templates_path(assets_path))

--- a/tests/base_backend_tests.py
+++ b/tests/base_backend_tests.py
@@ -20,7 +20,8 @@ import os  # noqa
 import re  # noqa
 from queue import Queue, Empty  # noqa
 from mock import patch  # noqa
-from errbot.backends.base import Identifier, Backend, Message  # noqa
+from errbot.backends.xmpp import XMPPIdentifier
+from errbot.backends.base import Backend, Message  # noqa
 from errbot.backends.base import build_message, build_text_html_message_pair  # noqa
 from errbot import botcmd, re_botcmd, arg_botcmd, templating  # noqa
 from errbot.utils import mess_2_embeddablehtml  # noqa
@@ -37,7 +38,7 @@ class Config:
 
 class DummyBackend(Backend):
     outgoing_message_queue = Queue()
-    jid = Identifier('err@localhost/err')
+    jid = XMPPIdentifier('err@localhost/err')
 
     def __init__(self, extra_config={}):
         self.bot_config = Config()
@@ -149,33 +150,33 @@ class TestBase(unittest.TestCase):
         self.dummy = DummyBackend()
 
     def test_identifier_parsing(self):
-        id1 = Identifier(jid='gbin@gootz.net/toto')
+        id1 = XMPPIdentifier(jid='gbin@gootz.net/toto')
         self.assertEqual(id1.node, 'gbin')
         self.assertEqual(id1.domain, 'gootz.net')
         self.assertEqual(id1.resource, 'toto')
 
-        id2 = Identifier(jid='gbin@gootz.net')
+        id2 = XMPPIdentifier(jid='gbin@gootz.net')
         self.assertEqual(id2.node, 'gbin')
         self.assertEqual(id2.domain, 'gootz.net')
         self.assertIsNone(id2.resource)
 
     def test_identifier_matching(self):
-        id1 = Identifier(jid='gbin@gootz.net/toto')
-        id2 = Identifier(jid='gbin@gootz.net/titi')
-        id3 = Identifier(jid='gbin@giitz.net/titi')
-        self.assertTrue(id1.bare_match(id2))
-        self.assertFalse(id2.bare_match(id3))
+        id1 = XMPPIdentifier(jid='gbin@gootz.net/toto')
+        id2 = XMPPIdentifier(jid='gbin@gootz.net/titi')
+        id3 = XMPPIdentifier(jid='gbin@giitz.net/titi')
+        self.assertTrue(id1.person == id2.person)
+        self.assertFalse(id2.person == id3.person)
 
     def test_identifier_stripping(self):
-        id1 = Identifier(jid='gbin@gootz.net/toto')
+        id1 = XMPPIdentifier(jid='gbin@gootz.net/toto')
         self.assertEqual(id1.stripped, 'gbin@gootz.net')
 
     def test_identifier_str_rep(self):
-        self.assertEqual(str(Identifier(jid="gbin@gootz.net/toto")), "gbin@gootz.net/toto")
-        self.assertEqual(str(Identifier(jid="gbin@gootz.net")), "gbin@gootz.net")
+        self.assertEqual(str(XMPPIdentifier(jid="gbin@gootz.net/toto")), "gbin@gootz.net/toto")
+        self.assertEqual(str(XMPPIdentifier(jid="gbin@gootz.net")), "gbin@gootz.net")
 
     def test_identifier_unicode_rep(self):
-        self.assertEqual(str(Identifier(jid="gbin@gootz.net/へようこそ")), "gbin@gootz.net/へようこそ")
+        self.assertEqual(str(XMPPIdentifier(jid="gbin@gootz.net/へようこそ")), "gbin@gootz.net/へようこそ")
 
     def test_xhtmlparsing_and_textify(self):
         text_plain, node = build_text_html_message_pair('<html><body>Message</body></html>')
@@ -185,7 +186,7 @@ class TestBase(unittest.TestCase):
         self.assertEqual(node.getchildren()[0].text, 'Message')
 
     def test_identifier_double_at_parsing(self):
-        id1 = Identifier(jid='gbin@titi.net@gootz.net/toto')
+        id1 = XMPPIdentifier(jid='gbin@titi.net@gootz.net/toto')
         self.assertEqual(id1.node, 'gbin@titi.net')
         self.assertEqual(id1.domain, 'gootz.net')
         self.assertEqual(id1.resource, 'toto')

--- a/tests/base_backend_tests.py
+++ b/tests/base_backend_tests.py
@@ -30,6 +30,7 @@ LONG_TEXT_STRING = "This is a relatively long line of output, but I am repeated 
 
 logging.basicConfig(level=logging.DEBUG)
 
+
 class Config:
     BOT_IDENTITY = {'username': 'err@localhost'}
     BOT_ASYNC = False
@@ -310,7 +311,7 @@ class BotCmds(unittest.TestCase):
         self.dummy.callback_message(m)
         self.assertRaises(Empty, self.dummy.pop_message, *[], **{'block': False})
 
-        m = self.makemessage("!return_args_as_str one two", from_ = SimpleMUCOccupant("someone@room"), type="groupchat")
+        m = self.makemessage("!return_args_as_str one two", from_=SimpleMUCOccupant("someone@room"), type="groupchat")
         self.dummy.callback_message(m)
         self.assertEquals("one two", self.dummy.pop_message().body)
 

--- a/tests/commands_tests.py
+++ b/tests/commands_tests.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 # create a mock configuration
+from errbot.backends import SimpleIdentifier
 from errbot.backends.test import FullStackTest, push_message, pop_message
 from queue import Empty
 import unittest
@@ -33,6 +34,7 @@ class TestCommands(FullStackTest):
         push_message('!status')
         self.assertIn('Yes I am alive', pop_message())
 
+    @unittest.skip("broken FIXME")
     def test_status_plugins(self):
         push_message('!status plugins')
         self.assertIn('L=Loaded, U=Unloaded', pop_message())
@@ -79,7 +81,7 @@ class TestCommands(FullStackTest):
         orig_sender = self.bot.sender
         try:
             # Pretend to be someone else. History should be empty
-            self.bot.sender = 'non_default_person@localhost'
+            self.bot.sender = SimpleIdentifier('non_default_person')
             push_message('!history')
             self.assertRaises(Empty, pop_message, block=False)
             push_message('!echo should be a separate history')
@@ -155,6 +157,8 @@ class TestCommands(FullStackTest):
         self.assertIn('Plugin configuration done.', pop_message())
         self.assertCommand("!webhook test /echo/ toto", 'Status code : 200')
 
+
+    @unittest.skip("broken FIXME")
     def test_load_reload_and_unload(self):
         for command in ('load', 'reload', 'unload'):
             push_message("!{}".format(command))
@@ -209,6 +213,7 @@ class TestCommands(FullStackTest):
         push_message('!unblacklist ChatRoom')
         pop_message()
 
+    @unittest.skip("broken FIXME")
     def test_unblacklist_and_blacklist(self):
         push_message('!unblacklist nosuchplugin')
         m = pop_message()

--- a/tests/commands_tests.py
+++ b/tests/commands_tests.py
@@ -157,7 +157,6 @@ class TestCommands(FullStackTest):
         self.assertIn('Plugin configuration done.', pop_message())
         self.assertCommand("!webhook test /echo/ toto", 'Status code : 200')
 
-
     @unittest.skip("broken FIXME")
     def test_load_reload_and_unload(self):
         for command in ('load', 'reload', 'unload'):

--- a/tests/commands_tests.py
+++ b/tests/commands_tests.py
@@ -34,7 +34,6 @@ class TestCommands(FullStackTest):
         push_message('!status')
         self.assertIn('Yes I am alive', pop_message())
 
-    @unittest.skip("broken FIXME")
     def test_status_plugins(self):
         push_message('!status plugins')
         self.assertIn('L=Loaded, U=Unloaded', pop_message())
@@ -157,7 +156,6 @@ class TestCommands(FullStackTest):
         self.assertIn('Plugin configuration done.', pop_message())
         self.assertCommand("!webhook test /echo/ toto", 'Status code : 200')
 
-    @unittest.skip("broken FIXME")
     def test_load_reload_and_unload(self):
         for command in ('load', 'reload', 'unload'):
             push_message("!{}".format(command))
@@ -212,7 +210,6 @@ class TestCommands(FullStackTest):
         push_message('!unblacklist ChatRoom')
         pop_message()
 
-    @unittest.skip("broken FIXME")
     def test_unblacklist_and_blacklist(self):
         push_message('!unblacklist nosuchplugin')
         m = pop_message()

--- a/tests/commands_tests.py
+++ b/tests/commands_tests.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 
 # create a mock configuration
-from errbot.backends import SimpleIdentifier
 from errbot.backends.test import FullStackTest, push_message, pop_message
 from queue import Empty
 import unittest
@@ -80,7 +79,7 @@ class TestCommands(FullStackTest):
         orig_sender = self.bot.sender
         try:
             # Pretend to be someone else. History should be empty
-            self.bot.sender = SimpleIdentifier('non_default_person')
+            self.bot.sender = self.bot.build_identifier('non_default_person')
             push_message('!history')
             self.assertRaises(Empty, pop_message, block=False)
             push_message('!echo should be a separate history')

--- a/tests/muc_tests.py
+++ b/tests/muc_tests.py
@@ -3,6 +3,7 @@ import errbot.backends.base
 from errbot.backends.test import push_message, pop_message
 from errbot.backends.test import testbot  # noqa
 import logging
+import unittest
 log = logging.getLogger(__name__)
 
 
@@ -16,6 +17,7 @@ class TestMUC(object):
         assert hasattr(p, 'rooms')
         assert hasattr(p, 'query_room')
 
+    @unittest.skip("broken FIXME")
     def test_create_join_leave_destroy_lifecycle(self, testbot):  # noqa
         rooms = testbot.bot.rooms()
         assert len(rooms) == 1
@@ -52,11 +54,13 @@ class TestMUC(object):
         rooms = testbot.bot.rooms()
         assert r2 not in rooms
 
+    @unittest.skip("broken FIXME")
     def test_occupants(self, testbot):  # noqa
         room = testbot.bot.rooms()[0]
         assert len(room.occupants) == 1
         assert 'err@localhost' in [str(o) for o in room.occupants]
 
+    @unittest.skip("broken FIXME")
     def test_topic(self, testbot):  # noqa
         room = testbot.bot.rooms()[0]
         assert room.topic is None
@@ -65,6 +69,7 @@ class TestMUC(object):
         assert room.topic == "Err rocks!"
         assert testbot.bot.rooms()[0].topic == "Err rocks!"
 
+    @unittest.skip("broken FIXME")
     def test_plugin_callbacks(self, testbot):  # noqa
         p = testbot.bot.get_plugin_obj_by_name('RoomTest')
         assert p is not None
@@ -80,6 +85,7 @@ class TestMUC(object):
         p.query_room('newroom@conference.server.tld').leave()
         assert p.events.get(timeout=5) == "callback_room_left newroom@conference.server.tld"
 
+    @unittest.skip("broken FIXME")
     def test_botcommands(self, testbot):  # noqa
         rooms = testbot.bot.rooms()
         room = testbot.bot.query_room('err@conference.server.tld')

--- a/tests/muc_tests.py
+++ b/tests/muc_tests.py
@@ -23,10 +23,10 @@ class TestMUC(object):
         assert len(rooms) == 1
 
         r1 = rooms[0]
-        assert str(r1) == "err@conference.server.tld"
+        assert str(r1) == "testroom"
         assert issubclass(r1.__class__, errbot.backends.base.MUCRoom)
 
-        r2 = testbot.bot.query_room('room@conference.server.tld')
+        r2 = testbot.bot.query_room('testroom2')
         assert not r2.exists
 
         r2.create()
@@ -45,7 +45,7 @@ class TestMUC(object):
         rooms = testbot.bot.rooms()
         assert r2 in rooms
 
-        r2 = testbot.bot.query_room('room@conference.server.tld')
+        r2 = testbot.bot.query_room('testroom2')
         assert r2.joined
 
         r2.leave()
@@ -57,7 +57,7 @@ class TestMUC(object):
     def test_occupants(self, testbot):  # noqa
         room = testbot.bot.rooms()[0]
         assert len(room.occupants) == 1
-        assert SimpleMUCOccupant('err@localhost') in room.occupants
+        assert SimpleMUCOccupant('err', 'testroom') in room.occupants
 
     def test_topic(self, testbot):  # noqa
         room = testbot.bot.rooms()[0]
@@ -73,62 +73,62 @@ class TestMUC(object):
         p.purge()
 
         log.debug("query and join")
-        p.query_room('newroom@conference.server.tld').join()
-        assert p.events.get(timeout=5) == "callback_room_joined newroom@conference.server.tld"
+        p.query_room('newroom').join()
+        assert p.events.get(timeout=5) == "callback_room_joined newroom"
 
-        p.query_room('newroom@conference.server.tld').topic = "Err rocks!"
+        p.query_room('newroom').topic = "Err rocks!"
         assert p.events.get(timeout=5) == "callback_room_topic Err rocks!"
 
-        p.query_room('newroom@conference.server.tld').leave()
-        assert p.events.get(timeout=5) == "callback_room_left newroom@conference.server.tld"
+        p.query_room('newroom').leave()
+        assert p.events.get(timeout=5) == "callback_room_left newroom"
 
     def test_botcommands(self, testbot):  # noqa
         rooms = testbot.bot.rooms()
-        room = testbot.bot.query_room('err@conference.server.tld')
+        room = testbot.bot.query_room('testroom')
         assert len(rooms) == 1
         assert rooms[0] == room
 
         assert room.joined
-        push_message("!room leave err@conference.server.tld")
-        assert pop_message() == "Left the room err@conference.server.tld"
-        room = testbot.bot.query_room('err@conference.server.tld')
+        push_message("!room leave testroom")
+        assert pop_message() == "Left the room testroom"
+        room = testbot.bot.query_room('testroom')
         assert not room.joined
 
         push_message("!room list")
         assert pop_message() == "I'm not currently in any rooms."
 
-        push_message("!room destroy err@conference.server.tld")
-        assert pop_message() == "Destroyed the room err@conference.server.tld"
+        push_message("!room destroy testroom")
+        assert pop_message() == "Destroyed the room testroom"
         rooms = testbot.bot.rooms()
-        room = testbot.bot.query_room('err@conference.server.tld')
+        room = testbot.bot.query_room('testroom')
         assert not room.exists
         assert room not in rooms
 
-        push_message("!room create err@conference.server.tld")
-        assert pop_message() == "Created the room err@conference.server.tld"
+        push_message("!room create testroom")
+        assert pop_message() == "Created the room testroom"
         rooms = testbot.bot.rooms()
-        room = testbot.bot.query_room('err@conference.server.tld')
+        room = testbot.bot.query_room('testroom')
         assert room.exists
         assert room not in rooms
         assert not room.joined
 
-        push_message("!room join err@conference.server.tld")
-        assert pop_message() == "Joined the room err@conference.server.tld"
+        push_message("!room join testroom")
+        assert pop_message() == "Joined the room testroom"
         rooms = testbot.bot.rooms()
-        room = testbot.bot.query_room('err@conference.server.tld')
+        room = testbot.bot.query_room('testroom')
         assert room.exists
         assert room.joined
         assert room in rooms
 
         push_message("!room list")
-        assert pop_message() == "I'm currently in these rooms:\n\terr@conference.server.tld"
+        assert pop_message() == "I'm currently in these rooms:\n\ttestroom"
 
-        push_message("!room occupants err@conference.server.tld")
-        assert pop_message() == "Occupants in err@conference.server.tld:\n\terr"
+        push_message("!room occupants testroom")
+        assert pop_message() == "Occupants in testroom:\n\terr"
 
-        push_message("!room topic err@conference.server.tld")
-        assert pop_message() == "No topic is set for err@conference.server.tld"
-        push_message("!room topic err@conference.server.tld 'Err rocks!'")
-        assert pop_message() == "Topic for err@conference.server.tld set."
-        push_message("!room topic err@conference.server.tld")
-        assert pop_message() == "Topic for err@conference.server.tld: Err rocks!"
+        push_message("!room topic testroom")
+        assert pop_message() == "No topic is set for testroom"
+        push_message("!room topic testroom 'Err rocks!'")
+        assert pop_message() == "Topic for testroom set."
+        push_message("!room topic testroom")
+        assert pop_message() == "Topic for testroom: Err rocks!"

--- a/tests/muc_tests.py
+++ b/tests/muc_tests.py
@@ -57,11 +57,6 @@ class TestMUC(object):
         assert len(room.occupants) == 1
         assert 'err@localhost' in [str(o) for o in room.occupants]
 
-        assert issubclass(
-            room.occupants[0].__class__,
-            errbot.backends.base.MUCOccupant
-        )
-
     def test_topic(self, testbot):  # noqa
         room = testbot.bot.rooms()[0]
         assert room.topic is None

--- a/tests/muc_tests.py
+++ b/tests/muc_tests.py
@@ -2,6 +2,7 @@ import os
 import errbot.backends.base
 from errbot.backends.test import push_message, pop_message
 from errbot.backends.test import testbot  # noqa
+from errbot.backends import SimpleMUCOccupant
 import logging
 import unittest
 log = logging.getLogger(__name__)
@@ -17,7 +18,6 @@ class TestMUC(object):
         assert hasattr(p, 'rooms')
         assert hasattr(p, 'query_room')
 
-    @unittest.skip("broken FIXME")
     def test_create_join_leave_destroy_lifecycle(self, testbot):  # noqa
         rooms = testbot.bot.rooms()
         assert len(rooms) == 1
@@ -54,13 +54,11 @@ class TestMUC(object):
         rooms = testbot.bot.rooms()
         assert r2 not in rooms
 
-    @unittest.skip("broken FIXME")
     def test_occupants(self, testbot):  # noqa
         room = testbot.bot.rooms()[0]
         assert len(room.occupants) == 1
-        assert 'err@localhost' in [str(o) for o in room.occupants]
+        assert SimpleMUCOccupant('err@localhost') in room.occupants
 
-    @unittest.skip("broken FIXME")
     def test_topic(self, testbot):  # noqa
         room = testbot.bot.rooms()[0]
         assert room.topic is None
@@ -69,7 +67,6 @@ class TestMUC(object):
         assert room.topic == "Err rocks!"
         assert testbot.bot.rooms()[0].topic == "Err rocks!"
 
-    @unittest.skip("broken FIXME")
     def test_plugin_callbacks(self, testbot):  # noqa
         p = testbot.bot.get_plugin_obj_by_name('RoomTest')
         assert p is not None
@@ -85,7 +82,6 @@ class TestMUC(object):
         p.query_room('newroom@conference.server.tld').leave()
         assert p.events.get(timeout=5) == "callback_room_left newroom@conference.server.tld"
 
-    @unittest.skip("broken FIXME")
     def test_botcommands(self, testbot):  # noqa
         rooms = testbot.bot.rooms()
         room = testbot.bot.query_room('err@conference.server.tld')
@@ -128,7 +124,7 @@ class TestMUC(object):
         assert pop_message() == "I'm currently in these rooms:\n\terr@conference.server.tld"
 
         push_message("!room occupants err@conference.server.tld")
-        assert pop_message() == "Occupants in err@conference.server.tld:\n\terr@localhost"
+        assert pop_message() == "Occupants in err@conference.server.tld:\n\terr"
 
         push_message("!room topic err@conference.server.tld")
         assert pop_message() == "No topic is set for err@conference.server.tld"

--- a/tests/simple_identifiers_tests.py
+++ b/tests/simple_identifiers_tests.py
@@ -1,0 +1,35 @@
+import unittest
+
+from errbot.backends import SimpleIdentifier, SimpleMUCOccupant
+
+
+class TestSimpleIdentifiers(unittest.TestCase):
+    def test_identifier_eq(self):
+        a = SimpleIdentifier("foo")
+        b = SimpleIdentifier("foo")
+        self.assertTrue(a == b)
+        self.assertEqual(a, b)
+
+    def test_identifier_ineq(self):
+        a = SimpleIdentifier("foo")
+        b = SimpleIdentifier("bar")
+        self.assertFalse(a == b)
+        self.assertNotEqual(a, b)
+
+    def test_mucidentifier_eq(self):
+        a = SimpleMUCOccupant("foo", "room")
+        b = SimpleMUCOccupant("foo", "room")
+        self.assertTrue(a == b)
+        self.assertEqual(a, b)
+
+    def test_mucidentifier_ineq1(self):
+        a = SimpleMUCOccupant("foo", "room")
+        b = SimpleMUCOccupant("bar", "room")
+        self.assertFalse(a == b)
+        self.assertNotEqual(a, b)
+
+    def test_mucidentifier_ineq2(self):
+        a = SimpleMUCOccupant("foo", "room1")
+        b = SimpleMUCOccupant("foo", "room2")
+        self.assertFalse(a == b)
+        self.assertNotEqual(a, b)

--- a/tests/streaming_test.py
+++ b/tests/streaming_test.py
@@ -1,7 +1,8 @@
 import unittest
 from io import BytesIO
 from errbot.streaming import Tee
-from errbot.backends.base import Stream, Identifier
+from errbot.backends.base import Stream
+from errbot.backends.text import SimpleIdentifier
 import logging
 
 
@@ -12,7 +13,7 @@ class StreamingClient(object):
 
 def test_streaming():
     canary = b'this is my test' * 1000
-    source = Stream(Identifier("gbin@gootz.net"), BytesIO(canary))
+    source = Stream(SimpleIdentifier("gbin@gootz.net"), BytesIO(canary))
     clients = [StreamingClient() for i in range(50)]
     Tee(source, clients).run()
     for client in clients:

--- a/tests/streaming_test.py
+++ b/tests/streaming_test.py
@@ -2,7 +2,7 @@ import unittest
 from io import BytesIO
 from errbot.streaming import Tee
 from errbot.backends.base import Stream
-from errbot.backends.text import SimpleIdentifier
+from errbot.backends import SimpleIdentifier
 import logging
 
 


### PR DESCRIPTION
This is a big refactoring.

Basically the goal is to provide a simpler contract for Identifiers that are not derived from XMPP.

Identifiers are now built from strings from the build_identifier that every backend needs to implement.

The minimal contract an identifier needs to provide: 
```
1. a __str__/__unicode__ to give a string representation that build_identifier can parse back
2. .person property that gives you a string representing a person
3. .client property that gives your from where the person is contacting you (phone, computer, web etc...)
```

For MUCIdentifier you need to add:
```
4. .room representing the room from which the message is coming from or going to
```