### PR TITLE
Ported backends as plugins.

### DIFF
--- a/errbot/backend_manager.py
+++ b/errbot/backend_manager.py
@@ -1,0 +1,75 @@
+import os
+import logging
+import sys
+
+from yapsy.PluginManager import PluginManager
+from yapsy.PluginFileLocator import PluginFileLocator, PluginFileAnalyzerWithInfoFile
+from errbot.errBot import ErrBot
+from .utils import find_roots_with_extra
+
+CORE_BACKENDS = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'backends')
+log = logging.getLogger(__name__)
+
+
+class SpecificBackendLocator(PluginFileAnalyzerWithInfoFile):
+    def __init__(self, name_to_find):
+        super().__init__('SpecificBackendLocator', 'plug')
+        self._name_to_find = name_to_find
+
+    def getInfosDictFromPlugin(self, dirpath, filename):
+        plugin_info_dict, config_parser = super().getInfosDictFromPlugin(dirpath, filename)
+        if plugin_info_dict['name'] != self._name_to_find:
+            # reject
+            return None, config_parser
+        return plugin_info_dict, config_parser
+
+
+class BackendManager(PluginManager):
+    """ BackendManager is a customized plugin manager to enumerate backends
+        and load only one.
+    """
+    def __init__(self, config):
+        self._config = config
+        # set a locator that gets every possible backends
+        self._locator = PluginFileLocator(analyzers=[PluginFileAnalyzerWithInfoFile('AllBackendLocator', 'plug')])
+        super().__init__(plugin_locator=self._locator)
+        self.setCategoriesFilter({'backend': ErrBot})
+        if hasattr(config, 'BOT_EXTRA_BACKEND_DIR'):
+            extra = config.BOT_EXTRA_BACKEND_DIR
+        else:
+            extra = []
+        all_backends_paths = find_roots_with_extra(CORE_BACKENDS, extra)
+        log.info('Backends search paths %s', all_backends_paths)
+        self.setPluginPlaces(all_backends_paths)
+        for entry in all_backends_paths:
+            if entry not in sys.path:
+                sys.path.append(entry)  # so backends can relatively import their submodules
+        self.locatePlugins()
+        log.info('Found those backends available:')
+        for (_, _, plug) in self.getPluginCandidates():
+            log.info('\t%10s  (%s)' % (plug.name, plug.path + '.py'))
+
+    def instanciateElement(self, element):
+        """ Override the loading method to inject config """
+        log.debug("Class to load %s" % element.__name__)
+        return element(self._config)
+
+    def get_candidate(self, name):
+        for (_, _, plug) in self.getPluginCandidates():
+            if plug.name == name:
+                return plug
+        raise Exception("Backend '%s' not found." % name)
+
+    def get_backend_by_name(self, name):
+        self._locator.setAnalyzers([SpecificBackendLocator(name)])
+        log.debug("Refilter the backend plugins...")
+        self.locatePlugins()
+        log.debug("Load the one remaining...")
+        self.loadPlugins()
+        log.debug("Find it back...")
+        plugins = self.getAllPlugins()
+        if len(plugins) == 0:
+            raise Exception("Could not find the backend '%s'." % name)
+        if len(plugins) != 1:
+            raise Exception("There are 2 backends with the name '%s'." % name)
+        return plugins[0].plugin_object

--- a/errbot/backend_manager.py
+++ b/errbot/backend_manager.py
@@ -12,6 +12,11 @@ log = logging.getLogger(__name__)
 
 
 class SpecificBackendLocator(PluginFileAnalyzerWithInfoFile):
+    """
+    This is a plugin locator (kind of filter in yapsy jargon) to match a backend.
+    We have to go through hoops because yapsy is really aggressive at instanciating plugin.
+    (this would instanciate several bots, we don't want to do that).
+    """
     def __init__(self, name_to_find):
         super().__init__('SpecificBackendLocator', 'plug')
         self._name_to_find = name_to_find
@@ -30,7 +35,7 @@ class BackendManager(PluginManager):
     """
     def __init__(self, config):
         self._config = config
-        # set a locator that gets every possible backends
+        # set a locator that gets every possible backends as a first discovery pass.
         self._locator = PluginFileLocator(analyzers=[PluginFileAnalyzerWithInfoFile('AllBackendLocator', 'plug')])
         super().__init__(plugin_locator=self._locator)
         self.setCategoriesFilter({'backend': ErrBot})
@@ -61,6 +66,7 @@ class BackendManager(PluginManager):
         raise Exception("Backend '%s' not found." % name)
 
     def get_backend_by_name(self, name):
+        # set a locator to narrow it to only one.
         self._locator.setAnalyzers([SpecificBackendLocator(name)])
         log.debug("Refilter the backend plugins...")
         self.locatePlugins()

--- a/errbot/backends/campfire.plug
+++ b/errbot/backends/campfire.plug
@@ -1,0 +1,6 @@
+[Core]
+Name = Campfire
+Module = campfire
+
+[Documentation]
+Description = This is the campfire backend for Err.

--- a/errbot/backends/graphic.plug
+++ b/errbot/backends/graphic.plug
@@ -1,0 +1,6 @@
+[Core]
+Name = Graphic
+Module = graphic
+
+[Documentation]
+Description = This is the graphic backend for Err.

--- a/errbot/backends/hipchat.plug
+++ b/errbot/backends/hipchat.plug
@@ -1,0 +1,6 @@
+[Core]
+Name = Hipchat
+Module = hipchat
+
+[Documentation]
+Description = This is the hipchat backend for Err.

--- a/errbot/backends/irc.plug
+++ b/errbot/backends/irc.plug
@@ -1,0 +1,6 @@
+[Core]
+Name = IRC
+Module = irc
+
+[Documentation]
+Description = This is the IRC backend for Err.

--- a/errbot/backends/null.plug
+++ b/errbot/backends/null.plug
@@ -1,0 +1,6 @@
+[Core]
+Name = Null
+Module = null
+
+[Documentation]
+Description = This is the Null backend for Err.

--- a/errbot/backends/slack.plug
+++ b/errbot/backends/slack.plug
@@ -1,0 +1,6 @@
+[Core]
+Name = Slack
+Module = slack
+
+[Documentation]
+Description = This is the slack backend for Err.

--- a/errbot/backends/test.plug
+++ b/errbot/backends/test.plug
@@ -1,0 +1,6 @@
+[Core]
+Name = Test
+Module = test
+
+[Documentation]
+Description = This is the test backend for Err.

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -9,16 +9,14 @@ from threading import Thread
 import pytest
 from errbot.backends import SimpleIdentifier, SimpleMUCOccupant
 
-log = logging.getLogger(__name__)
-
-# Errbot machinery must not be imported before this point
-# because of the import hackery above.
 from errbot.backends.base import (
-    Message, build_message, MUCRoom  # noqa
+    Message, build_message, MUCRoom
 )
-from errbot.core_plugins.wsview import reset_app  # noqa
-from errbot.errBot import ErrBot  # noqa
-from errbot.main import setup_bot  # noqa
+from errbot.core_plugins.wsview import reset_app
+from errbot.errBot import ErrBot
+from errbot.main import setup_bot
+
+log = logging.getLogger(__name__)
 
 QUIT_MESSAGE = '$STOP$'
 

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -332,7 +332,6 @@ class TestBot(object):
         assert 'not found' not in self.bot.pop_message(timeout)
 
 
-
 class FullStackTest(unittest.TestCase, TestBot):
     """
     Test class for use with Python's unittest module to write tests

--- a/errbot/backends/text.plug
+++ b/errbot/backends/text.plug
@@ -1,0 +1,6 @@
+[Core]
+Name = Text
+Module = text
+
+[Documentation]
+Description = This is the text backend for Err.

--- a/errbot/backends/tox.plug
+++ b/errbot/backends/tox.plug
@@ -1,0 +1,6 @@
+[Core]
+Name = Tox
+Module = tox
+
+[Documentation]
+Description = This is the TOX backend for Err.

--- a/errbot/backends/xmpp.plug
+++ b/errbot/backends/xmpp.plug
@@ -1,0 +1,6 @@
+[Core]
+Name = XMPP
+Module = xmpp
+
+[Documentation]
+Description = This is the XMPP backend for Err.

--- a/errbot/main.py
+++ b/errbot/main.py
@@ -73,6 +73,12 @@ def setup_bot(backend_name, logger, config, restore=None):
         log.error('Some plugins failed to load:\n' + '\n'.join(errors))
     return bot
 
+def enumerate_backends(config):
+    """ Returns all the backends found for the given config.
+    """
+    bpm = BackendManager(config)
+    return [plug.name for (_, _, plug) in bpm.getPluginCandidates()]
+
 
 def main(bot_class, logger, config, restore=None):
     bot = setup_bot(bot_class, logger, config, restore)

--- a/errbot/main.py
+++ b/errbot/main.py
@@ -1,11 +1,12 @@
 from os import path, makedirs
 import logging
+from errbot.backend_manager import BackendManager
 import sys
 
 log = logging.getLogger(__name__)
 
 
-def setup_bot(bot_class, logger, config, restore=None):
+def setup_bot(backend_name, logger, config, restore=None):
     # from here the environment is supposed to be set (daemon / non daemon,
     # config.py in the python path )
 
@@ -40,8 +41,16 @@ def setup_bot(bot_class, logger, config, restore=None):
     d = path.join(config.BOT_DATA_DIR, PLUGINS_SUBDIR)
     if not path.exists(d):
         makedirs(d, mode=0o755)
+
+    # instanciate the bot
+    bpm = BackendManager(config)
+
+    plug = bpm.get_candidate(backend_name)
+
+    log.info("Found Backend plugin: '%s'\n\t\t\t\t\t\tDescription: %s" % (plug.name, plug.description))
+
     try:
-        bot = bot_class(config)
+        bot = bpm.get_backend_by_name(backend_name)
     except Exception:
         log.exception("Unable to configure the backend, please check if your config.py is correct.")
         exit(-1)

--- a/errbot/main.py
+++ b/errbot/main.py
@@ -73,6 +73,7 @@ def setup_bot(backend_name, logger, config, restore=None):
         log.error('Some plugins failed to load:\n' + '\n'.join(errors))
     return bot
 
+
 def enumerate_backends(config):
     """ Returns all the backends found for the given config.
     """

--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import fnmatch
 import inspect
 import logging
 import os
@@ -285,3 +286,24 @@ def repeatfunc(func, times=None, *args):  # from the itertools receipes
     if times is None:
         return starmap(func, repeat(args))
     return starmap(func, repeat(args, times))
+
+
+def find_roots(path, file_sig='*.plug'):
+    """Collects all the paths from path recursively that contains files of type file_sig"""
+    roots = set()  # you can have several .plug per directory.
+    for root, dirnames, filenames in os.walk(path):
+        for filename in fnmatch.filter(filenames, file_sig):
+            roots.add(os.path.dirname(os.path.join(root, filename)))
+    return roots
+
+
+def find_roots_with_extra(base, extra, file_sig='*.plug'):
+    # adds the extra plugin dir from the setup for developers convenience
+    all_base_and_extra = [base]
+    if extra:
+        if isinstance(extra, list):
+            for path in extra:
+                all_base_and_extra.extend(find_roots(path, file_sig))
+        else:
+            all_base_and_extra.extend(find_roots(extra, file_sig))
+    return all_base_and_extra

--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -289,7 +289,13 @@ def repeatfunc(func, times=None, *args):  # from the itertools receipes
 
 
 def find_roots(path, file_sig='*.plug'):
-    """Collects all the paths from path recursively that contains files of type file_sig"""
+    """Collects all the paths from path recursively that contains files of type `file_sig`.
+       :param base:
+            a base path to walk from
+       :param file_sig:
+            the file pattern to look for
+       :return: a set of paths
+    """
     roots = set()  # you can have several .plug per directory.
     for root, dirnames, filenames in os.walk(path):
         for filename in fnmatch.filter(filenames, file_sig):
@@ -298,6 +304,15 @@ def find_roots(path, file_sig='*.plug'):
 
 
 def find_roots_with_extra(base, extra, file_sig='*.plug'):
+    """Collects all the paths from path recursively that contains files of type `file_sig`.
+       :param base:
+            a base path to walk from
+       :param extra:
+            a extra dorectory or directories to walk from
+       :param file_sig:
+            the file pattern to look for
+       :return: a set of paths
+    """
     # adds the extra plugin dir from the setup for developers convenience
     all_base_and_extra = [base]
     if extra:

--- a/scripts/err.py
+++ b/scripts/err.py
@@ -186,6 +186,8 @@ if __name__ == "__main__":
         backend = 'Null'  # we don't want any backend when we restore
     elif filtered_mode:
         backend = classic_vs_plugin_names[filtered_mode[0]]
+    elif args['backend']:
+        backend = args['backend']
     else:
         backend = 'XMPP'  # default value
 

--- a/tests/backend_manager_tests.py
+++ b/tests/backend_manager_tests.py
@@ -1,0 +1,15 @@
+import unittest
+
+from errbot.backend_manager import BackendManager
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+
+class TestBackendsManager(unittest.TestCase):
+    def test_builtins(self):
+        bpm = BackendManager({})
+        backend_plug = bpm.getPluginCandidates()
+        names = [plug.name for (_, _, plug) in backend_plug]
+        assert 'Text' in names
+        assert 'Test' in names
+        assert 'Null' in names

--- a/tests/commands_tests.py
+++ b/tests/commands_tests.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 
 # create a mock configuration
-from errbot.backends.test import FullStackTest, push_message, pop_message
+from errbot.backends.test import FullStackTest
 from queue import Empty
 import unittest
 import re
@@ -9,231 +9,207 @@ import re
 
 class TestCommands(FullStackTest):
     def test_root_help(self):
-        push_message('!help')
-        self.assertIn('Available help', pop_message())
+        self.assertCommand('!help', 'Available help')
 
     def test_help(self):
-        push_message('!help ErrBot')
-        response = pop_message()
-        self.assertIn('Available commands for ErrBot', response)
-        self.assertIn('!about', response)
-
-        push_message('!help beurk')
-        self.assertEqual('That command is not defined.', pop_message())
+        self.assertCommand('!help ErrBot', 'Available commands for ErrBot')
+        self.assertCommand('!help ErrBot', '!about')
+        self.assertCommand('!help beurk', 'That command is not defined.')
 
     def test_about(self):
-        push_message('!about')
-        self.assertIn('Err version', pop_message())
+        self.assertCommand('!about', 'Err version')
 
     def test_uptime(self):
-        push_message('!uptime')
-        self.assertIn('I\'ve been up for', pop_message())
+        self.assertCommand('!uptime', 'I\'ve been up for')
 
     def test_status(self):
-        push_message('!status')
-        self.assertIn('Yes I am alive', pop_message())
+        self.assertCommand('!status', 'Yes I am alive')
 
     def test_status_plugins(self):
-        push_message('!status plugins')
-        self.assertIn('L=Loaded, U=Unloaded', pop_message())
+        self.assertCommand('!status plugins', 'L=Loaded, U=Unloaded')
 
     def test_status_load(self):
-        push_message('!status load')
-        self.assertIn('Load ', pop_message())
+        self.assertCommand('!status load', 'Load ')
 
     def test_status_gc(self):
-        push_message('!status gc')
-        self.assertIn('GC 0->', pop_message())
+        self.assertCommand('!status gc', 'GC 0->')
 
     def test_config_cycle(self):
-        push_message('!config Webserver')
-        m = pop_message()
+        self.bot.push_message('!config Webserver')
+        m = self.bot.pop_message()
         self.assertIn('Default configuration for this plugin (you can copy and paste this directly as a command)', m)
         self.assertNotIn('Current configuration', m)
 
-        push_message("!config Webserver {'HOST': 'localhost', 'PORT': 3141, 'SSL':  None}")
-        self.assertIn('Plugin configuration done.', pop_message())
+        self.assertCommand("!config Webserver {'HOST': 'localhost', 'PORT': 3141, 'SSL':  None}",
+                           'Plugin configuration done.')
 
-        push_message('!config Webserver')
-        m = pop_message()
-        self.assertIn('Current configuration', m)
-        self.assertIn('localhost', m)
-
-        push_message('!config Webserver')
-        self.assertIn('localhost', pop_message())
+        self.assertCommand('!config Webserver', 'Current configuration')
+        self.assertCommand('!config Webserver', 'localhost')
 
     def test_apropos(self):
-        push_message('!apropos about')
-        self.assertIn('!about: Returns some', pop_message())
+        self.assertCommand('!apropos about', '!about: Returns some')
 
     def test_logtail(self):
-        push_message('!log tail')
-        self.assertIn('DEBUG', pop_message())
+        self.assertCommand('!log tail', 'DEBUG')
 
     def test_history(self):
-        push_message('!uptime')
-        pop_message()
-        push_message('!history')
-        self.assertIn('uptime', pop_message())
+        self.assertCommand('!uptime', 'up')
+        self.assertCommand('!history', 'uptime')
 
         orig_sender = self.bot.sender
         try:
             # Pretend to be someone else. History should be empty
             self.bot.sender = self.bot.build_identifier('non_default_person')
-            push_message('!history')
-            self.assertRaises(Empty, pop_message, block=False)
-            push_message('!echo should be a separate history')
-            pop_message()
-            push_message('!history')
-            self.assertIn('should be a separate history', pop_message())
+            self.bot.push_message('!history')
+            self.assertRaises(Empty, self.bot.pop_message, block=False)
+            self.bot.push_message('!echo should be a separate history')
+            self.bot.pop_message()
+            self.assertCommand('!history', 'should be a separate history')
         finally:
             self.bot.sender = orig_sender
         # Pretend to be the original person again. History should still contain uptime
-        push_message('!history')
-        self.assertIn('uptime', pop_message())
+        self.assertCommand('!history', 'uptime')
 
     def test_plugin_cycle(self):
-        push_message('!repos install git://github.com/gbin/err-helloworld.git')
-        self.assertIn('err-helloworld', pop_message(timeout=60))
-        self.assertIn('reload', pop_message())
+        self.assertCommand('!repos install git://github.com/gbin/err-helloworld.git',
+                           'err-helloworld',
+                           60)
+        self.assertIn('reload', self.bot.pop_message())
 
-        push_message('!help hello')  # should appear in the help
-        self.assertEqual("this command says hello", pop_message())
+        self.assertCommand('!help hello', 'this command says hello')
+        self.assertCommand('!hello', 'Hello World !')
 
-        push_message('!hello')  # should respond
-        self.assertEqual('Hello World !', pop_message())
+        self.bot.push_message('!reload HelloWorld')
+        self.assertEqual('Plugin HelloWorld deactivated', self.bot.pop_message())
+        self.assertEqual('Plugin HelloWorld activated', self.bot.pop_message())
 
-        push_message('!reload HelloWorld')
-        self.assertEqual('Plugin HelloWorld deactivated', pop_message())
-        self.assertEqual('Plugin HelloWorld activated', pop_message())
+        self.bot.push_message('!hello')  # should still respond
+        self.assertEqual('Hello World !', self.bot.pop_message())
 
-        push_message('!hello')  # should still respond
-        self.assertEqual('Hello World !', pop_message())
+        self.bot.push_message('!blacklist HelloWorld')
+        self.assertEqual('Plugin HelloWorld is now blacklisted', self.bot.pop_message())
+        self.bot.push_message('!unload HelloWorld')
+        self.assertEqual('Plugin HelloWorld deactivated', self.bot.pop_message())
 
-        push_message('!blacklist HelloWorld')
-        self.assertEqual('Plugin HelloWorld is now blacklisted', pop_message())
-        push_message('!unload HelloWorld')
-        self.assertEqual('Plugin HelloWorld deactivated', pop_message())
+        self.bot.push_message('!hello')  # should not respond
+        self.assertIn('Command "hello" not found', self.bot.pop_message())
 
-        push_message('!hello')  # should not respond
-        self.assertIn('Command "hello" not found', pop_message())
+        self.bot.push_message('!unblacklist HelloWorld')
+        self.assertEqual('Plugin HelloWorld removed from blacklist', self.bot.pop_message())
+        self.bot.push_message('!load HelloWorld')
+        self.assertEqual('Plugin HelloWorld activated', self.bot.pop_message())
 
-        push_message('!unblacklist HelloWorld')
-        self.assertEqual('Plugin HelloWorld removed from blacklist', pop_message())
-        push_message('!load HelloWorld')
-        self.assertEqual('Plugin HelloWorld activated', pop_message())
+        self.bot.push_message('!hello')  # should respond back
+        self.assertEqual('Hello World !', self.bot.pop_message())
 
-        push_message('!hello')  # should respond back
-        self.assertEqual('Hello World !', pop_message())
+        self.bot.push_message('!repos uninstall err-helloworld')
+        self.assertEqual('/me is unloading plugin HelloWorld', self.bot.pop_message())
+        self.assertEqual('Plugins unloaded and repo err-helloworld removed', self.bot.pop_message())
 
-        push_message('!repos uninstall err-helloworld')
-        self.assertEqual('/me is unloading plugin HelloWorld', pop_message())
-        self.assertEqual('Plugins unloaded and repo err-helloworld removed', pop_message())
-
-        push_message('!hello')  # should not respond
-        self.assertIn('Command "hello" not found', pop_message())
+        self.bot.push_message('!hello')  # should not respond
+        self.assertIn('Command "hello" not found', self.bot.pop_message())
 
     def test_backup(self):
-        push_message('!repos install git://github.com/gbin/err-helloworld.git')
-        self.assertIn('err-helloworld', pop_message(timeout=60))
-        self.assertIn('reload', pop_message())
-        push_message('!backup')
-        msg = pop_message()
+        self.bot.push_message('!repos install git://github.com/gbin/err-helloworld.git')
+        self.assertIn('err-helloworld', self.bot.pop_message(timeout=60))
+        self.assertIn('reload', self.bot.pop_message())
+        self.bot.push_message('!backup')
+        msg = self.bot.pop_message()
         self.assertIn('has been written in', msg)
         filename = re.search(r"'([A-Za-z0-9_\./\\-]*)'", msg).group(1)
         # At least the backup should mention the installed plugin
 
         self.assertIn('err-helloworld', open(filename).read())
-        push_message('!repos uninstall err-helloworld')
+        self.bot.push_message('!repos uninstall err-helloworld')
 
     def test_encoding_preservation(self):
-        push_message('!echo へようこそ')
-        self.assertEquals('へようこそ', pop_message())
+        self.bot.push_message('!echo へようこそ')
+        self.assertEquals('へようこそ', self.bot.pop_message())
 
     def test_webserver_webhook_test(self):
-        push_message("!config Webserver {'HOST': 'localhost', 'PORT': 3141, 'SSL':  None}")
-        self.assertIn('Plugin configuration done.', pop_message())
+        self.bot.push_message("!config Webserver {'HOST': 'localhost', 'PORT': 3141, 'SSL':  None}")
+        self.assertIn('Plugin configuration done.', self.bot.pop_message())
         self.assertCommand("!webhook test /echo/ toto", 'Status code : 200')
 
     def test_load_reload_and_unload(self):
         for command in ('load', 'reload', 'unload'):
-            push_message("!{}".format(command))
-            m = pop_message()
+            self.bot.push_message("!{}".format(command))
+            m = self.bot.pop_message()
             self.assertIn('Please tell me which of the following plugins to reload', m)
             self.assertIn('ChatRoom', m)
 
-            push_message('!{} nosuchplugin'.format(command))
-            m = pop_message()
+            self.bot.push_message('!{} nosuchplugin'.format(command))
+            m = self.bot.pop_message()
             self.assertIn("nosuchplugin isn't a valid plugin name. The current plugins are", m)
             self.assertIn('ChatRoom', m)
 
-        push_message('!reload ChatRoom')
-        self.assertEqual('Plugin ChatRoom deactivated', pop_message())
-        self.assertEqual('Plugin ChatRoom activated', pop_message())
+        self.bot.push_message('!reload ChatRoom')
+        self.assertEqual('Plugin ChatRoom deactivated', self.bot.pop_message())
+        self.assertEqual('Plugin ChatRoom activated', self.bot.pop_message())
 
-        push_message("!status plugins")
-        self.assertIn("[L] ChatRoom", pop_message())
+        self.bot.push_message("!status plugins")
+        self.assertIn("[L] ChatRoom", self.bot.pop_message())
 
-        push_message('!unload ChatRoom')
-        self.assertEqual('Plugin ChatRoom deactivated', pop_message())
+        self.bot.push_message('!unload ChatRoom')
+        self.assertEqual('Plugin ChatRoom deactivated', self.bot.pop_message())
 
-        push_message("!status plugins")
-        self.assertIn("[U] ChatRoom", pop_message())
+        self.bot.push_message("!status plugins")
+        self.assertIn("[U] ChatRoom", self.bot.pop_message())
 
-        push_message('!unload ChatRoom')
-        self.assertEqual('ChatRoom is not currently loaded', pop_message())
+        self.bot.push_message('!unload ChatRoom')
+        self.assertEqual('ChatRoom is not currently loaded', self.bot.pop_message())
 
-        push_message('!load ChatRoom')
-        self.assertEqual('Plugin ChatRoom activated', pop_message())
+        self.bot.push_message('!load ChatRoom')
+        self.assertEqual('Plugin ChatRoom activated', self.bot.pop_message())
 
-        push_message("!status plugins")
-        self.assertIn("[L] ChatRoom", pop_message())
+        self.bot.push_message("!status plugins")
+        self.assertIn("[L] ChatRoom", self.bot.pop_message())
 
-        push_message('!load ChatRoom')
-        self.assertEqual('ChatRoom is already loaded', pop_message())
+        self.bot.push_message('!load ChatRoom')
+        self.assertEqual('ChatRoom is already loaded', self.bot.pop_message())
 
-        push_message('!unload ChatRoom')
-        self.assertEqual('Plugin ChatRoom deactivated', pop_message())
-        push_message('!reload ChatRoom')
-        self.assertEqual('Plugin ChatRoom not in active list', pop_message())
-        self.assertEqual('Plugin ChatRoom activated', pop_message())
+        self.bot.push_message('!unload ChatRoom')
+        self.assertEqual('Plugin ChatRoom deactivated', self.bot.pop_message())
+        self.bot.push_message('!reload ChatRoom')
+        self.assertEqual('Plugin ChatRoom not in active list', self.bot.pop_message())
+        self.assertEqual('Plugin ChatRoom activated', self.bot.pop_message())
 
-        push_message('!blacklist ChatRoom')
-        self.assertEqual("Plugin ChatRoom is now blacklisted", pop_message())
+        self.bot.push_message('!blacklist ChatRoom')
+        self.assertEqual("Plugin ChatRoom is now blacklisted", self.bot.pop_message())
 
-        push_message("!status plugins")
-        self.assertIn("[B,L] ChatRoom", pop_message())
+        self.bot.push_message("!status plugins")
+        self.assertIn("[B,L] ChatRoom", self.bot.pop_message())
 
         # Needed else configuration for this plugin gets saved which screws up
         # other tests
-        push_message('!unblacklist ChatRoom')
-        pop_message()
+        self.bot.push_message('!unblacklist ChatRoom')
+        self.bot.pop_message()
 
     def test_unblacklist_and_blacklist(self):
-        push_message('!unblacklist nosuchplugin')
-        m = pop_message()
+        self.bot.push_message('!unblacklist nosuchplugin')
+        m = self.bot.pop_message()
         self.assertIn("nosuchplugin isn't a valid plugin name. The current plugins are", m)
         self.assertIn('ChatRoom', m)
 
-        push_message('!blacklist nosuchplugin')
-        m = pop_message()
+        self.bot.push_message('!blacklist nosuchplugin')
+        m = self.bot.pop_message()
         self.assertIn("nosuchplugin isn't a valid plugin name. The current plugins are", m)
         self.assertIn('ChatRoom', m)
 
-        push_message('!blacklist ChatRoom')
-        self.assertEqual("Plugin ChatRoom is now blacklisted", pop_message())
+        self.bot.push_message('!blacklist ChatRoom')
+        self.assertEqual("Plugin ChatRoom is now blacklisted", self.bot.pop_message())
 
-        push_message('!blacklist ChatRoom')
-        self.assertEqual("Plugin ChatRoom is already blacklisted", pop_message())
+        self.bot.push_message('!blacklist ChatRoom')
+        self.assertEqual("Plugin ChatRoom is already blacklisted", self.bot.pop_message())
 
-        push_message("!status plugins")
-        self.assertIn("[B,L] ChatRoom", pop_message())
+        self.bot.push_message("!status plugins")
+        self.assertIn("[B,L] ChatRoom", self.bot.pop_message())
 
-        push_message('!unblacklist ChatRoom')
-        self.assertEqual('Plugin ChatRoom removed from blacklist', pop_message())
+        self.bot.push_message('!unblacklist ChatRoom')
+        self.assertEqual('Plugin ChatRoom removed from blacklist', self.bot.pop_message())
 
-        push_message('!unblacklist ChatRoom')
-        self.assertEqual('Plugin ChatRoom is not blacklisted', pop_message())
+        self.bot.push_message('!unblacklist ChatRoom')
+        self.assertEqual('Plugin ChatRoom is not blacklisted', self.bot.pop_message())
 
-        push_message("!status plugins")
-        self.assertIn("[L] ChatRoom", pop_message())
+        self.bot.push_message("!status plugins")
+        self.assertIn("[L] ChatRoom", self.bot.pop_message())

--- a/tests/dummy_plugin/dummy.plug
+++ b/tests/dummy_plugin/dummy.plug
@@ -1,0 +1,6 @@
+[Core]
+Name = Dummy
+Module = dummy
+
+[Python]
+Version = 2+

--- a/tests/dummy_plugin/dummy.py
+++ b/tests/dummy_plugin/dummy.py
@@ -1,0 +1,9 @@
+from errbot import BotPlugin, botcmd
+
+
+class DummyTest(BotPlugin):
+    """Just a test plugin to see if it is picked up.
+    """
+    @botcmd
+    def foo(self, msg, args):
+        return 'bar'

--- a/tests/muc_tests.py
+++ b/tests/muc_tests.py
@@ -1,74 +1,76 @@
 import os
 import errbot.backends.base
-from errbot.backends.test import push_message, pop_message
-from errbot.backends.test import testbot  # noqa
 from errbot.backends import SimpleMUCOccupant
+from errbot.backends.test import FullStackTest
 import logging
 import unittest
 log = logging.getLogger(__name__)
 
 
-class TestMUC(object):
-    extra_plugin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'room_tests')
+class TestMUC(FullStackTest):
 
-    def test_plugin_methods(self, testbot):  # noqa
-        p = testbot.bot.get_plugin_obj_by_name('ChatRoom')
+    def setUp(self, extra_plugin_dir=None, extra_test_file=None, loglevel=logging.DEBUG):
+        super().setUp(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'room_tests'),
+                      extra_test_file)
+
+    def test_plugin_methods(self):  # noqa
+        p = self.bot.get_plugin_obj_by_name('ChatRoom')
         assert p is not None
 
         assert hasattr(p, 'rooms')
         assert hasattr(p, 'query_room')
 
-    def test_create_join_leave_destroy_lifecycle(self, testbot):  # noqa
-        rooms = testbot.bot.rooms()
+    def test_create_join_leave_destroy_lifecycle(self):  # noqa
+        rooms = self.bot.rooms()
         assert len(rooms) == 1
 
         r1 = rooms[0]
         assert str(r1) == "testroom"
         assert issubclass(r1.__class__, errbot.backends.base.MUCRoom)
 
-        r2 = testbot.bot.query_room('testroom2')
+        r2 = self.bot.query_room('testroom2')
         assert not r2.exists
 
         r2.create()
         assert r2.exists
-        rooms = testbot.bot.rooms()
+        rooms = self.bot.rooms()
         assert r2 not in rooms
         assert not r2.joined
 
         r2.destroy()
-        rooms = testbot.bot.rooms()
+        rooms = self.bot.rooms()
         assert r2 not in rooms
 
         r2.join()
         assert r2.exists
         assert r2.joined
-        rooms = testbot.bot.rooms()
+        rooms = self.bot.rooms()
         assert r2 in rooms
 
-        r2 = testbot.bot.query_room('testroom2')
+        r2 = self.bot.query_room('testroom2')
         assert r2.joined
 
         r2.leave()
         assert not r2.joined
         r2.destroy()
-        rooms = testbot.bot.rooms()
+        rooms = self.bot.rooms()
         assert r2 not in rooms
 
-    def test_occupants(self, testbot):  # noqa
-        room = testbot.bot.rooms()[0]
+    def test_occupants(self):  # noqa
+        room = self.bot.rooms()[0]
         assert len(room.occupants) == 1
         assert SimpleMUCOccupant('err', 'testroom') in room.occupants
 
-    def test_topic(self, testbot):  # noqa
-        room = testbot.bot.rooms()[0]
+    def test_topic(self):  # noqa
+        room = self.bot.rooms()[0]
         assert room.topic is None
 
         room.topic = "Err rocks!"
         assert room.topic == "Err rocks!"
-        assert testbot.bot.rooms()[0].topic == "Err rocks!"
+        assert self.bot.rooms()[0].topic == "Err rocks!"
 
-    def test_plugin_callbacks(self, testbot):  # noqa
-        p = testbot.bot.get_plugin_obj_by_name('RoomTest')
+    def test_plugin_callbacks(self):  # noqa
+        p = self.bot.get_plugin_obj_by_name('RoomTest')
         assert p is not None
         p.purge()
 
@@ -82,53 +84,53 @@ class TestMUC(object):
         p.query_room('newroom').leave()
         assert p.events.get(timeout=5) == "callback_room_left newroom"
 
-    def test_botcommands(self, testbot):  # noqa
-        rooms = testbot.bot.rooms()
-        room = testbot.bot.query_room('testroom')
+    def test_botcommands(self):  # noqa
+        rooms = self.bot.rooms()
+        room = self.bot.query_room('testroom')
         assert len(rooms) == 1
         assert rooms[0] == room
 
         assert room.joined
-        push_message("!room leave testroom")
-        assert pop_message() == "Left the room testroom"
-        room = testbot.bot.query_room('testroom')
+        self.bot.push_message("!room leave testroom")
+        assert self.bot.pop_message() == "Left the room testroom"
+        room = self.bot.query_room('testroom')
         assert not room.joined
 
-        push_message("!room list")
-        assert pop_message() == "I'm not currently in any rooms."
+        self.bot.push_message("!room list")
+        assert self.bot.pop_message() == "I'm not currently in any rooms."
 
-        push_message("!room destroy testroom")
-        assert pop_message() == "Destroyed the room testroom"
-        rooms = testbot.bot.rooms()
-        room = testbot.bot.query_room('testroom')
+        self.bot.push_message("!room destroy testroom")
+        assert self.bot.pop_message() == "Destroyed the room testroom"
+        rooms = self.bot.rooms()
+        room = self.bot.query_room('testroom')
         assert not room.exists
         assert room not in rooms
 
-        push_message("!room create testroom")
-        assert pop_message() == "Created the room testroom"
-        rooms = testbot.bot.rooms()
-        room = testbot.bot.query_room('testroom')
+        self.bot.push_message("!room create testroom")
+        assert self.bot.pop_message() == "Created the room testroom"
+        rooms = self.bot.rooms()
+        room = self.bot.query_room('testroom')
         assert room.exists
         assert room not in rooms
         assert not room.joined
 
-        push_message("!room join testroom")
-        assert pop_message() == "Joined the room testroom"
-        rooms = testbot.bot.rooms()
-        room = testbot.bot.query_room('testroom')
+        self.bot.push_message("!room join testroom")
+        assert self.bot.pop_message() == "Joined the room testroom"
+        rooms = self.bot.rooms()
+        room = self.bot.query_room('testroom')
         assert room.exists
         assert room.joined
         assert room in rooms
 
-        push_message("!room list")
-        assert pop_message() == "I'm currently in these rooms:\n\ttestroom"
+        self.bot.push_message("!room list")
+        assert self.bot.pop_message() == "I'm currently in these rooms:\n\ttestroom"
 
-        push_message("!room occupants testroom")
-        assert pop_message() == "Occupants in testroom:\n\terr"
+        self.bot.push_message("!room occupants testroom")
+        assert self.bot.pop_message() == "Occupants in testroom:\n\terr"
 
-        push_message("!room topic testroom")
-        assert pop_message() == "No topic is set for testroom"
-        push_message("!room topic testroom 'Err rocks!'")
-        assert pop_message() == "Topic for testroom set."
-        push_message("!room topic testroom")
-        assert pop_message() == "Topic for testroom: Err rocks!"
+        self.bot.push_message("!room topic testroom")
+        assert self.bot.pop_message() == "No topic is set for testroom"
+        self.bot.push_message("!room topic testroom 'Err rocks!'")
+        assert self.bot.pop_message() == "Topic for testroom set."
+        self.bot.push_message("!room topic testroom")
+        assert self.bot.pop_message() == "Topic for testroom: Err rocks!"

--- a/tests/plugin_management_tests.py
+++ b/tests/plugin_management_tests.py
@@ -1,7 +1,8 @@
 import os
 import unittest
 import tempfile
-from errbot.plugin_manager import check_dependencies, get_preloaded_plugins, CORE_PLUGINS, find_plugin_roots
+from errbot.plugin_manager import check_dependencies, CORE_PLUGINS
+from errbot.utils import find_roots, find_roots_with_extra
 
 
 def touch(name):
@@ -26,7 +27,7 @@ class TestPluginManagement(unittest.TestCase):
         touch(os.path.join(a, 'toto.plug'))
         touch(os.path.join(b, 'titi.plug'))
         touch(os.path.join(root, 'tutu.plug'))
-        roots = find_plugin_roots(root)
+        roots = find_roots(root)
         self.assertIn(root, roots)
         self.assertIn(a, roots)
         self.assertIn(b, roots)
@@ -38,7 +39,7 @@ class TestPluginManagement(unittest.TestCase):
         touch(os.path.join(toto, 'titi.plug'))
         titi = tempfile.mkdtemp()
         touch(os.path.join(titi, 'tata.plug'))
-        self.assertEquals(get_preloaded_plugins(None), [CORE_PLUGINS])
-        self.assertEquals(get_preloaded_plugins(toto), [CORE_PLUGINS, toto])
-        self.assertEquals(get_preloaded_plugins([toto, titi]), [CORE_PLUGINS, toto, titi])
-        self.assertEquals(get_preloaded_plugins([toto, titi, 'nothing']), [CORE_PLUGINS, toto, titi])
+        self.assertEquals(find_roots_with_extra(CORE_PLUGINS, None), [CORE_PLUGINS])
+        self.assertEquals(find_roots_with_extra(CORE_PLUGINS, toto), [CORE_PLUGINS, toto])
+        self.assertEquals(find_roots_with_extra(CORE_PLUGINS, [toto, titi]), [CORE_PLUGINS, toto, titi])
+        self.assertEquals(find_roots_with_extra(CORE_PLUGINS, [toto, titi, 'nothing']), [CORE_PLUGINS, toto, titi])

--- a/tests/pytestfixtures_tests.py
+++ b/tests/pytestfixtures_tests.py
@@ -5,14 +5,15 @@ from errbot.backends.test import testbot
 
 extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'dummy_plugin')
 
+
 def test_push_pull(testbot):
     testbot.push_message('!about')
     assert "Err version" in testbot.pop_message()
 
+
 def test_assertCommand(testbot):
     testbot.assertCommand('!about', 'Err version')
 
+
 def test_extra_plugin_dir(testbot):
     testbot.assertCommand('!foo', 'bar')
-
-

--- a/tests/pytestfixtures_tests.py
+++ b/tests/pytestfixtures_tests.py
@@ -1,0 +1,18 @@
+from os import path
+from errbot.backends.test import testbot
+
+# This is to test the pytestfixtures pattern.
+
+extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'dummy_plugin')
+
+def test_push_pull(testbot):
+    testbot.push_message('!about')
+    assert "Err version" in testbot.pop_message()
+
+def test_assertCommand(testbot):
+    testbot.assertCommand('!about', 'Err version')
+
+def test_extra_plugin_dir(testbot):
+    testbot.assertCommand('!foo', 'bar')
+
+


### PR DESCRIPTION
This allows third party backends to be run by err.

backends have the same .plug as a normal err plugin.
The backend has to be a subclass of ErrBot.

The port had a ripple effect across the test codebase that has to be cleaned up as we were doing dodgy things like globals (yapsy loads plugins in a virtual modules).

err can now be started with a backend name with -b or --backend.

Another new command line parameter -l to list the available backends
will be added in another PR.