### PR TITLE
Fixes related to groupchat replies

### DIFF
--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -1071,7 +1071,7 @@ class Backend(object):
         nick_reply = self.bot_config.GROUPCHAT_NICK_PREFIXED
 
         if (message_type == 'groupchat' and in_reply_to and nick_reply and groupchat_nick_reply):
-            reply_text = self.groupchat_reply_format().format(in_reply_to.nick, text)
+            reply_text = self.groupchat_reply_format().format(user.node, text)
         else:
             reply_text = text
 

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -1071,7 +1071,7 @@ class Backend(object):
         nick_reply = self.bot_config.GROUPCHAT_NICK_PREFIXED
 
         if (message_type == 'groupchat' and in_reply_to and nick_reply and groupchat_nick_reply):
-            reply_text = self.groupchat_reply_format().format(user.node, text)
+            reply_text = self.groupchat_reply_format().format(user=user.node, reply=text)
         else:
             reply_text = text
 

--- a/errbot/backends/campfire.py
+++ b/errbot/backends/campfire.py
@@ -127,4 +127,4 @@ class CampfireBackend(ErrBot):
         return 'campfire'
 
     def groupchat_reply_format(self):
-        return '@{0} {1}'
+        return '@{user} {reply}'

--- a/errbot/backends/graphic.py
+++ b/errbot/backends/graphic.py
@@ -240,4 +240,4 @@ class GraphicBackend(TextBackend):
         return 'graphic'
 
     def groupchat_reply_format(self):
-        return '{0} {1}'
+        return '{user} {reply}'

--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -384,4 +384,4 @@ class HipchatBackend(XMPPBackend):
         return HipChatMUCRoom(name, self)
 
     def groupchat_reply_format(self):
-        return '@{0} {1}'
+        return '@{user} {reply}'

--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -356,4 +356,4 @@ class IRCBackend(ErrBot):
         return [IRCMUCRoom(channel, self) for channel in channels]
 
     def groupchat_reply_format(self):
-        return '{0}: {1}'
+        return '{user}: {reply}'

--- a/errbot/backends/null.py
+++ b/errbot/backends/null.py
@@ -63,3 +63,6 @@ class NullBackend(ErrBot):
     @property
     def mode(self):
         return 'null'
+
+    def groupchat_reply_format(self):
+        return '{user} {reply}'

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -438,7 +438,7 @@ class SlackBackend(ErrBot):
         return [SlackRoom(channelid=channel['id'], bot=self) for channel in channels]
 
     def groupchat_reply_format(self):
-        return '@{0}: {1}'
+        return '@{user}: {reply}'
 
 
 class SlackRoom(MUCRoom):

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -204,7 +204,7 @@ class TestBackend(ErrBot):
             return r
 
     def groupchat_reply_format(self):
-        return '{0} {1}'
+        return '{user} {reply}'
 
     def pop_message(self, timeout=5, block=True):
         return self.outgoing_message_queue.get(timeout=timeout, block=block)

--- a/errbot/backends/text.py
+++ b/errbot/backends/text.py
@@ -87,7 +87,7 @@ class TextBackend(ErrBot):
         return self.rooms
 
     def groupchat_reply_format(self):
-        return '{0} {1}'
+        return '{user} {reply}'
 
 
 class TextMUCRoom(MUCRoom):

--- a/errbot/backends/tox.py
+++ b/errbot/backends/tox.py
@@ -428,4 +428,4 @@ class ToxBackend(ErrBot):
         return None
 
     def groupchat_reply_format(self):
-        return '@{0} {1}'
+        return '@{user} {reply}'

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -625,4 +625,4 @@ class XMPPBackend(ErrBot):
         return XMPPMUCRoom(room, bot=self)
 
     def groupchat_reply_format(self):
-        return '@{0} {1}'
+        return '@{user} {reply}'


### PR DESCRIPTION
Fixed issue where replies in groupchat returned the userid instead of the username in slackbackend.
It also uses the new muc identifiers.

I also update the variables to be more descriptive to each backend.

Sijis