### PR TITLE
introduce nick and fullname in generic identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,11 +9,7 @@ nohup.out
 /dist
 /err.egg-info*
 /config-*.egg
-config_campfire.py
-config_hipchat.py
-config_irc.py
-config_xmpp.py
-config_tox.py
+/config*.py
 /docs/_build
 /docs/_gh-pages
 /docs/errbot.rst

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Stuff that might break you:
 
 - XMPP properties .node, .domain and .resource on identifiers are deprecated, a backward compatibility layer has been added but we highly encourage you to not rely on those but use the generic ones from now on: .person, .client and for MUCOccupants .room on top of .person and .client.
 - To create identifiers from a string (i.e. if you don't get it from the bot itself) you now have to use build_identifier(string) to make the backend parse it
+- command line parameter -c needs to be the full path of your config file, it allows us to have different set of configs to test the bot.
 
 Version 2.3.0-rc2 (2015-07-06)
 ------------------------------

--- a/errbot/backends/__init__.py
+++ b/errbot/backends/__init__.py
@@ -29,9 +29,11 @@ class SimpleIdentifier(DeprecationBridgeIdentifier):
         use self.build_identifier(identifier_as_string) instead.
     """
 
-    def __init__(self, person, client=None):
+    def __init__(self, person, client=None, nick=None, fullname=None):
         self._person = person
         self._client = client
+        self._nick = nick
+        self._fullname = fullname
 
     @property
     def person(self):
@@ -43,6 +45,18 @@ class SimpleIdentifier(DeprecationBridgeIdentifier):
         """This needs to return the part of the identifier pointing to a client from which a person is sending a message from.
         Returns None is unspecified"""
         return self._client
+
+    @property
+    def nick(self):
+        """This needs to return a short display name for this identifier e.g. gbin.
+        Returns None is unspecified"""
+        return self._nick
+
+    @property
+    def fullname(self):
+        """This needs to return a long display name for this identifier e.g. Guillaume Binet.
+        Returns None is unspecified"""
+        return self._fullname
 
     def __unicode__(self):
         if self.client:

--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -50,6 +50,11 @@ class IRCIdentifier(DeprecationBridgeIdentifier):
     # generic compatibility
     person = nick
 
+    @property
+    def fullname(self):
+        # TODO: this should be possible to get
+        return None
+
     def __unicode__(self):
         return "%s!%s" % (self._nick, self._domain)
 

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -112,10 +112,7 @@ class SlackIdentifier(DeprecationBridgeIdentifier):
         return user.real_name
 
     def __unicode__(self):
-        if self.channelname:
-            return "%s@%s/%s" % (self.username, self.domain, self.channelname)
-        else:
-            return "%s@%s" % (self.username, self.domain)
+        return "@%s" % self.username
 
     def __str__(self):
         return self.__unicode__()
@@ -126,6 +123,11 @@ class SlackMUCOccupant(SlackIdentifier):
     This class represents a person inside a MUC.
     """
     room = SlackIdentifier.channelname
+    def __unicode__(self):
+        return "#%s/%s" % (self.room, self.username)
+
+    def __str__(self):
+        return self.__unicode__()
 
 
 class SlackBackend(ErrBot):
@@ -375,31 +377,29 @@ class SlackBackend(ErrBot):
         return build_message(text, Message)
 
     def build_identifier(self, txtrep):
-        """ username@domainname/channelname
-            or username/channelname
-            or username
-            domain is actually pointless as it will be self.sc.server.domain
-            """
-        if '@' in txtrep:
-            username, domain_channel = txtrep.split('@')
-            if '/' in domain_channel:
-                domain, channelname = domain_channel.split('/')
-            else:
-                domainname = domain_channel
-                channel = None
+        """ #channelname/username
+            or @username
+        """
+        log.debug("building an identifier from %s" % txtrep)
+        txtrep = txtrep.strip()
+        channelname = None
+
+        if txtrep[0] == '@':
+            username = txtrep[1:]
+        elif txtrep[0] == '#':
+            plainrep = txtrep[1:]
+            if '/' not in txtrep:
+              raise Exception("Unparseable slack identifier, should be #channelname/username or @username : '%s'" % txtrep)
+            channelname, username = plainrep.split('/')
         else:
-            if '/' in txtrep:
-                username, channelname = txtrep.split('/')
-            else:
-                username = txtrep
+            raise Exception("Unparseable slack identifier, should be #channelname/username or @username : '%s'" % txtrep)
 
         userid = self.username_to_userid(username)
         if channelname:
             channelid = self.channelname_to_channelid(channelname)
-        else:
-            channelid = None
+            return SlackMUCOccupant(self.sc, userid, channelid)
 
-        return SlackIdentifier(self.sc, userid, channelid)
+        return SlackIdentifier(self.sc, userid, self.get_im_channel(userid))
 
     def build_reply(self, mess, text=None, private=False):
         msg_type = mess.type

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -99,8 +99,17 @@ class SlackIdentifier(DeprecationBridgeIdentifier):
         return self._sc.server.domain
 
     # Compatibility with the generic API.
-    person = username
-    client = channelname
+    person = userid
+    client = channelid
+    nick = username
+
+    @property
+    def fullname(self):
+        """Convert a Slack user ID to their user name"""
+        user = self._sc.server.users.find(self._userid)
+        if user is None:
+            raise UserDoesNotExistError("Cannot find user with ID %s" % self._userid)
+        return user.real_name
 
     def __unicode__(self):
         if self.channelname:

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -123,6 +123,7 @@ class SlackMUCOccupant(SlackIdentifier):
     This class represents a person inside a MUC.
     """
     room = SlackIdentifier.channelname
+
     def __unicode__(self):
         return "#%s/%s" % (self.room, self.username)
 
@@ -389,10 +390,12 @@ class SlackBackend(ErrBot):
         elif txtrep[0] == '#':
             plainrep = txtrep[1:]
             if '/' not in txtrep:
-              raise Exception("Unparseable slack identifier, should be #channelname/username or @username : '%s'" % txtrep)
+                raise Exception("Unparseable slack identifier, " +
+                                "should be #channelname/username or @username : '%s'" % txtrep)
             channelname, username = plainrep.split('/')
         else:
-            raise Exception("Unparseable slack identifier, should be #channelname/username or @username : '%s'" % txtrep)
+            raise Exception("Unparseable slack identifier, " +
+                            "should be #channelname/username or @username : '%s'" % txtrep)
 
         userid = self.username_to_userid(username)
         if channelname:

--- a/errbot/backends/tox.py
+++ b/errbot/backends/tox.py
@@ -54,6 +54,18 @@ class ToxIdentifier(object):
     def person(self):
         return self._username
 
+    @property
+    def client(self):
+        return None
+
+    @property
+    def nick(self):
+        return self._username
+
+    @property
+    def fullname(self):
+        return None
+
 
 class ToxStreamer(io.BufferedRWPair):
     def __init__(self):

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -86,6 +86,14 @@ class XMPPIdentifier(object):
         return self._node + '@' + self._domain
 
     @property
+    def nick(self):
+        return self._node
+
+    @property
+    def fullname(self):
+        return None  # Not supported by default on XMPP.
+
+    @property
     def stripped(self):
         log.warning('stripped is deprecated, use .person on identifiers instead')
         return self.person

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -371,7 +371,22 @@ class ErrBot(Backend, StoreMixin, BotPluginManager):
         """
         return args
 
-    # noinspection PyUnusedLocal
+    @botcmd
+    def whoami(self, mess, args):
+        """ A simple command echoing the details of your identifier. Useful to debug identity problems.
+        """
+        frm = mess.frm
+        resp = "\n`person` is %s\n" % frm.person
+        resp += "\n`nick` is %s\n" % frm.nick
+        resp += "\n`fullname` is %s\n" % frm.fullname
+        resp += "\n`client` is %s\n" % frm.client
+
+        #  extra info if it is a MUC
+        if hasattr(frm, 'room'):
+            resp += "\n`room` is %s\n" % frm.room
+
+        return resp
+
     @botcmd
     def uptime(self, mess, args):
         """ Return the uptime of the bot

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -384,6 +384,7 @@ class ErrBot(Backend, StoreMixin, BotPluginManager):
         #  extra info if it is a MUC
         if hasattr(frm, 'room'):
             resp += "\n`room` is %s\n" % frm.room
+        resp += "\n\nstring representation is %s\n" % frm
 
         return resp
 

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -375,7 +375,10 @@ class ErrBot(Backend, StoreMixin, BotPluginManager):
     def whoami(self, mess, args):
         """ A simple command echoing the details of your identifier. Useful to debug identity problems.
         """
-        frm = mess.frm
+        if args:
+            frm = self.build_identifier(str(args).strip('"'))
+        else:
+            frm = mess.frm
         resp = "\n`person` is %s\n" % frm.person
         resp += "\n`nick` is %s\n" % frm.nick
         resp += "\n`fullname` is %s\n" % frm.fullname
@@ -385,6 +388,7 @@ class ErrBot(Backend, StoreMixin, BotPluginManager):
         if hasattr(frm, 'room'):
             resp += "\n`room` is %s\n" % frm.room
         resp += "\n\nstring representation is '%s'\n" % frm
+        resp += "\nclass is '%s'\n" % frm.__class__.__name__
 
         return resp
 

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -384,7 +384,7 @@ class ErrBot(Backend, StoreMixin, BotPluginManager):
         #  extra info if it is a MUC
         if hasattr(frm, 'room'):
             resp += "\n`room` is %s\n" % frm.room
-        resp += "\n\nstring representation is %s\n" % frm
+        resp += "\n\nstring representation is '%s'\n" % frm
 
         return resp
 

--- a/scripts/err.py
+++ b/scripts/err.py
@@ -90,12 +90,11 @@ logger.addHandler(console_hdlr)
 def get_config(config_path):
     __import__('errbot.config-template')  # - is on purpose, it should not be imported normally ;)
     template = sys.modules['errbot.config-template']
-    config_fullpath = config_path + sep + 'config.py'
-
+    config_fullpath = config_path
     if not path.exists(config_fullpath):
         log.error(
-            'I cannot find the file config.py in the directory %s \n'
-            '(You can change this directory with the -c parameter see --help)' % config_path
+            'I cannot find the file %s \n'
+            '(You can change this path with the -c parameter see --help)' % config_path
         )
         log.info(
             'You can use the template %s as a base and copy it to %s. \nYou can then customize it.' % (
@@ -105,7 +104,7 @@ def get_config(config_path):
 
     # noinspection PyBroadException
     try:
-        config = __import__('config')
+        config = __import__(path.splitext(path.basename(config_fullpath))[0])
 
         diffs = [item for item in set(dir(template)) - set(dir(config)) if not item.startswith('_')]
         if diffs:
@@ -130,7 +129,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description='The main entry point of the XMPP bot err.')
     parser.add_argument('-c', '--config', default=None,
-                        help='Specify the directory where your config.py is (default: current working directory).')
+                        help='Full path to your config.py (default: config.py in current working directory).')
     parser.add_argument('-r', '--restore', nargs='?', default=None, const='default',
                         help='Restores a bot from backup.py. (default: backup.py from the bot data directory).')
     parser.add_argument('-l', '--list', action='store_true', help='Lists all the backends found.')
@@ -156,9 +155,10 @@ if __name__ == "__main__":
     config_path = args['config']
     # setup the environment to be able to import the config.py
     if config_path:
-        sys.path.insert(0, config_path)  # appends the current config in order to find config.py
+        # appends the current config in order to find config.py
+        sys.path.insert(0, path.dirname(path.abspath(config_path)))
     else:
-        config_path = execution_dir
+        config_path = execution_dir + sep + 'config.py'
 
     config = get_config(config_path)  # will exit if load fails
     if args['list']:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [pep8]
 max-line-length = 120
-exclude = errbot/bundled/*,docs/*,config.py,errbot/config-*.py,build/*
+exclude = errbot/bundled/*,docs/*,config*.py,errbot/config-*.py,build/*
 
 [pytest]
 addopts = --ignore run_tests.py


### PR DESCRIPTION

This allows to separate the technical identifiers:
.person
.client

to the human ones for display only:
.nick
.fullname

This is needed because quite a few backends have unreadable technical identifiers unlike XMPP.