### PR TITLE
[Slack] Match ACLs against username rather than cryptic userid

### DIFF
--- a/errbot/backends/__init__.py
+++ b/errbot/backends/__init__.py
@@ -58,10 +58,22 @@ class SimpleIdentifier(DeprecationBridgeIdentifier):
         Returns None is unspecified"""
         return self._fullname
 
+    @property
+    def aclattr(self):
+        """
+        Return an identifier that is suitable for ACL checks.
+
+        Back-ends can override this to allow ACL checks against a more
+        human-readable name even if it uses cryptic IDs under the hood.
+        (See the Slack back-end for an example)
+        """
+        return self.person
+
     def __unicode__(self):
         if self.client:
             return self._person + "/" + self._client
         return self._person
+
     __str__ = __unicode__
 
     def __eq__(self, other):

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -4,7 +4,7 @@ import re
 import time
 import sys
 from errbot import PY3
-from errbot.backends import DeprecationBridgeIdentifier
+from errbot.backends import SimpleIdentifier
 from errbot.backends.base import (
     Message, Presence, ONLINE, AWAY,
     MUCRoom, RoomDoesNotExistError, UserDoesNotExistError
@@ -53,7 +53,7 @@ class SlackAPIResponseError(RuntimeError):
     """Slack API returned a non-OK response"""
 
 
-class SlackIdentifier(DeprecationBridgeIdentifier):
+class SlackIdentifier(SimpleIdentifier):
     # TODO(gbin): remove this deprecation warnings at one point.
 
     def __init__(self, sc, userid, channelid=None):
@@ -110,6 +110,10 @@ class SlackIdentifier(DeprecationBridgeIdentifier):
         if user is None:
             raise UserDoesNotExistError("Cannot find user with ID %s" % self._userid)
         return user.real_name
+
+    @property
+    def aclattr(self):
+        return self.nick
 
     def __unicode__(self):
         return "@%s" % self.username

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -2,8 +2,10 @@ import logging
 import sys
 import warnings
 
+from errbot.backends import SimpleIdentifier
 from errbot.backends.base import (
-    Message, MUCRoom, Presence, RoomNotJoinedError)
+    Message, MUCRoom, Presence, RoomNotJoinedError
+)
 from errbot.backends.base import ONLINE, OFFLINE, AWAY, DND
 from errbot.errBot import ErrBot
 from threading import Thread
@@ -58,7 +60,7 @@ def verify_gtalk_cert(xmpp_client):
     log.error("invalid cert received for %s", xmpp_client.boundjid.server)
 
 
-class XMPPIdentifier(object):
+class XMPPIdentifier(SimpleIdentifier):
     """
     This class is the parent and the basic contract of all the ways the backends
     are identifying a person on their system.

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -381,7 +381,7 @@ class ErrBot(Backend, BotPluginManager):
 
         Raises ACLViolation() if the command may not be executed in the given context
         """
-        usr = str(mess.frm.person)
+        usr = mess.frm.aclattr
         typ = mess.type
 
         if cmd not in self.bot_config.ACCESS_CONTROLS:


### PR DESCRIPTION
This will allow people to enter people's usernames for ACL entries
rather than having to look up their user IDs (which isn't easy to do).