### PR TITLE
Move custom exceptions to errbot.exceptions

### DIFF
--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -11,30 +11,15 @@ from xml.etree.cElementTree import ParseError
 from errbot import botcmd, PY2
 from errbot.utils import get_sender_username, deprecated, compat_str
 
+# Backward-compatibility in case there are plugins importing them from
+# this module still. These were moved in Err 3.0.0 so this should be
+# removed when 4.0.0 is released.
+from errbot.exceptions import (
+    ACLViolation, RoomError, RoomNotJoinedError, RoomDoesNotExistError,
+    UserDoesNotExistError
+)
+
 log = logging.getLogger(__name__)
-
-
-class ACLViolation(Exception):
-    """Exceptions raised when user is not allowed to execute given command due to ACLs"""
-
-
-class RoomError(Exception):
-    """General exception class for MUC-related errors"""
-
-
-class RoomNotJoinedError(RoomError):
-    """Exception raised when performing MUC operations
-    that require the bot to have joined the room"""
-
-
-class RoomDoesNotExistError(RoomError):
-    """Exception that is raised when performing an operation
-    on a room that doesn't exist"""
-
-
-class UserDoesNotExistError(Exception):
-    """Exception that is raised when performing an operation
-    on a user that doesn't exist"""
 
 
 class Message(object):

--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -7,7 +7,7 @@ from markdown.extensions.extra import ExtraExtension
 from markdown.extensions import Extension
 from markdown.treeprocessors import Treeprocessor
 
-from errbot.backends.base import RoomDoesNotExistError
+from errbot.exceptions import RoomDoesNotExistError
 from errbot.backends.xmpp import XMPPMUCOccupant, XMPPMUCRoom, XMPPBackend, XMPPConnection
 log = logging.getLogger(__name__)
 

--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -7,7 +7,8 @@ import subprocess
 import struct
 
 from errbot.backends import DeprecationBridgeIdentifier
-from errbot.backends.base import Message, MUCRoom, RoomError, RoomNotJoinedError, Stream
+from errbot.backends.base import Message, MUCRoom, Stream
+from errbot.exceptions import RoomError, RoomNotJoinedError
 from errbot.errBot import ErrBot
 from errbot.utils import RateLimited
 from errbot.rendering.ansi import AnsiExtension, enable_format, CharacterTable, NSC

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -5,9 +5,9 @@ import time
 import sys
 from errbot import PY3
 from errbot.backends import DeprecationBridgeIdentifier
-from errbot.backends.base import (
-    Message, Presence, ONLINE, AWAY,
-    MUCRoom, RoomDoesNotExistError, UserDoesNotExistError
+from errbot.backends.base import Message, Presence, ONLINE, AWAY, MUCRoom
+from errbot.exceptions import (
+    SlackAPIResponseError, RoomDoesNotExistError, UserDoesNotExistError
 )
 from errbot.errBot import ErrBot
 from errbot.utils import deprecated
@@ -48,10 +48,6 @@ except SyntaxError:
 # link if you prefix it with a #. Other clients receive this link as a
 # token matching this regex.
 SLACK_CLIENT_CHANNEL_HYPERLINK = re.compile(r'^<#(?P<id>(C|G)[0-9A-Z]+)>$')
-
-
-class SlackAPIResponseError(RuntimeError):
-    """Slack API returned a non-OK response"""
 
 
 class SlackIdentifier(DeprecationBridgeIdentifier):

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -2,9 +2,9 @@ import logging
 import sys
 import warnings
 
-from errbot.backends.base import (
-    Message, MUCRoom, Presence, RoomNotJoinedError)
+from errbot.backends.base import Message, MUCRoom, Presence
 from errbot.backends.base import ONLINE, OFFLINE, AWAY, DND
+from errbot.exceptions import RoomNotJoinedError
 from errbot.errBot import ErrBot
 from errbot.rendering import text, xhtml
 from threading import Thread

--- a/errbot/exceptions.py
+++ b/errbot/exceptions.py
@@ -1,0 +1,49 @@
+class ACLViolation(Exception):
+    """Exceptions raised when user is not allowed to execute given command due to ACLs"""
+
+
+class RoomError(Exception):
+    """General exception class for MUC-related errors"""
+
+
+class RoomNotJoinedError(RoomError):
+    """Exception raised when performing MUC operations
+    that require the bot to have joined the room"""
+
+
+class RoomDoesNotExistError(RoomError):
+    """Exception that is raised when performing an operation
+    on a room that doesn't exist"""
+
+
+class UserDoesNotExistError(Exception):
+    """Exception that is raised when performing an operation
+    on a user that doesn't exist"""
+
+
+class SlackAPIResponseError(RuntimeError):
+    """Slack API returned a non-OK response"""
+
+
+class IncompatiblePluginException(Exception):
+    pass
+
+
+class PluginConfigurationException(Exception):
+    pass
+
+
+class StoreException(Exception):
+    pass
+
+
+class StoreAlreadyOpenError(StoreException):
+    pass
+
+
+class StoreNotOpenError(StoreException):
+    pass
+
+
+class ValidationException(Exception):
+    pass

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -9,6 +9,7 @@ import subprocess
 import pip
 from . import PY2
 from .botplugin import BotPlugin
+from .exceptions import IncompatiblePluginException, PluginConfigurationException
 from .utils import version2array, PY3, find_roots, find_roots_with_extra, PLUGINS_SUBDIR, which, human_name_for_git_url
 from .templating import remove_plugin_templates_path, add_plugin_templates_path
 from .version import VERSION
@@ -26,14 +27,6 @@ try:
     from importlib import reload  # new in python 3.4
 except ImportError:
     from imp import reload
-
-
-class IncompatiblePluginException(Exception):
-    pass
-
-
-class PluginConfigurationException(Exception):
-    pass
 
 
 def populate_doc(plugin):

--- a/errbot/storage.py
+++ b/errbot/storage.py
@@ -3,19 +3,9 @@ import logging
 import shelve
 
 from . import PY2
+from .exceptions import StoreAlreadyOpenError, StoreNotOpenError
+
 log = logging.getLogger(__name__)
-
-
-class StoreException(Exception):
-    pass
-
-
-class StoreAlreadyOpenError(StoreException):
-    pass
-
-
-class StoreNotOpenError(StoreException):
-    pass
 
 
 class StoreMixin(MutableMapping):

--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -6,6 +6,7 @@ import os
 import re
 import sys
 import time
+from errbot.exceptions import ValidationException
 from platform import system
 from functools import wraps
 from html import entities
@@ -158,10 +159,6 @@ def version2array(version):
         raise ValueError(INVALID_VERSION_EXCEPTION % version)
 
     return response
-
-
-class ValidationException(Exception):
-    pass
 
 
 def recurse_check_structure(sample, to_check):


### PR DESCRIPTION
This moves all custom exception classes to a new `errbot.exceptions`
module. This makes them easier to find and avoids the situation where
trying to catch exceptions raised by back-ends fails because of Yapsy
loading it as a new "dynamic" Python module.

Closes #418