### PR TITLE
Provide a logger to plugins

### DIFF
--- a/docs/user_guide/plugin_development/index.rst
+++ b/docs/user_guide/plugin_development/index.rst
@@ -18,3 +18,4 @@ Plugins form the heart of Err. From the ground up, it is designed to be extended
   scheduling
   webhooks
   testing
+  logging

--- a/docs/user_guide/plugin_development/logging.rst
+++ b/docs/user_guide/plugin_development/logging.rst
@@ -1,0 +1,15 @@
+Logging
+-------
+
+Logging information on what your plugin is doing can be a tremendous asset when managing your bot in production, especially when something is going wrong.
+
+Err uses the standard Python `logging <https://docs.python.org/3/library/logging.html>`_ library to log messages internally and provides a logger for your own plugins to use as well as `self.log`.
+You can use this logger to log status messages to the log like this:
+
+.. code-block:: python
+
+    from errbot import BotPlugin
+
+    class PluginExample(BotPlugin):
+        def callback_message(self, message):
+            self.log.info("I just received a message!")

--- a/docs/user_guide/plugin_development/presence.rst
+++ b/docs/user_guide/plugin_development/presence.rst
@@ -16,15 +16,14 @@ in order to receive notifications of presence changes. You will receive
 a :class:`~errbot.backends.base.Presence` object for every presence change
 received by Err.
 
-Here's an example which simply logs each presence change to the root logger
+Here's an example which simply logs each presence change to the log
 when it includes a status message:
 
 .. code-block:: python
 
-    import logging
     from errbot import BotPlugin
 
     class PluginExample(BotPlugin):
         def callback_presence(self, presence):
             if presence.get_message() is not None:
-                logging.info(presence)
+                self.log.info(presence)

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -11,7 +11,8 @@ from xml.etree.cElementTree import ParseError
 from errbot import botcmd, PY2
 from errbot.utils import get_sender_username, deprecated, compat_str
 
-log = logging.getLogger(__name__)
+# Can't use __name__ because of Yapsy
+log = logging.getLogger('errbot.backends.base')
 
 
 class ACLViolation(Exception):

--- a/errbot/backends/graphic.py
+++ b/errbot/backends/graphic.py
@@ -8,7 +8,8 @@ from errbot.backends.base import Message
 from errbot.backends.text import TextBackend   # we use that as we emulate MUC there already
 from errbot.rendering import xhtml
 
-log = logging.getLogger(__name__)
+# Can't use __name__ because of Yapsy
+log = logging.getLogger('errbot.backends.graphic')
 
 try:
     from PySide import QtCore, QtGui, QtWebKit

--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -9,7 +9,9 @@ from markdown.treeprocessors import Treeprocessor
 
 from errbot.backends.base import RoomDoesNotExistError
 from errbot.backends.xmpp import XMPPMUCOccupant, XMPPMUCRoom, XMPPBackend, XMPPConnection
-log = logging.getLogger(__name__)
+
+# Can't use __name__ because of Yapsy
+log = logging.getLogger('errbot.backends.hipchat')
 
 try:
     import hypchat

--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -15,7 +15,8 @@ from errbot.rendering.ansi import AnsiExtension, enable_format, CharacterTable, 
 from markdown import Markdown
 from markdown.extensions.extra import ExtraExtension
 
-log = logging.getLogger(__name__)
+# Can't use __name__ because of Yapsy
+log = logging.getLogger('errbot.backends.irc')
 
 IRC_CHRS = CharacterTable(fg_black=NSC('\x0301'),
                           fg_red=NSC('\x0304'),

--- a/errbot/backends/null.py
+++ b/errbot/backends/null.py
@@ -4,7 +4,8 @@ from errbot.backends.base import Message
 from errbot.backends import SimpleIdentifier
 from errbot.errBot import ErrBot
 
-log = logging.getLogger(__name__)
+# Can't use __name__ because of Yapsy
+log = logging.getLogger('errbot.backends.null')
 
 
 class ConnectionMock():

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -13,7 +13,8 @@ from errbot.errBot import ErrBot
 from errbot.utils import deprecated
 from errbot.rendering import imtext
 
-log = logging.getLogger(__name__)
+# Can't use __name__ because of Yapsy
+log = logging.getLogger('errbot.backends.slack')
 
 try:
     from functools import lru_cache

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -14,7 +14,8 @@ from errbot.core_plugins.wsview import reset_app
 from errbot.errBot import ErrBot
 from errbot.main import setup_bot
 
-log = logging.getLogger(__name__)
+# Can't use __name__ because of Yapsy
+log = logging.getLogger('errbot.backends.test')
 
 QUIT_MESSAGE = '$STOP$'
 

--- a/errbot/backends/text.py
+++ b/errbot/backends/text.py
@@ -12,7 +12,8 @@ from pygments import highlight
 from pygments.formatters import Terminal256Formatter
 from pygments.lexers import get_lexer_by_name
 
-log = logging.getLogger(__name__)
+# Can't use __name__ because of Yapsy
+log = logging.getLogger('errbot.backends.text')
 
 ENCODING_INPUT = sys.stdin.encoding
 ANSI = hasattr(sys.stderr, 'isatty') and sys.stderr.isatty()

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -11,7 +11,8 @@ from threading import Thread
 from time import sleep
 from errbot.utils import deprecated
 
-log = logging.getLogger(__name__)
+# Can't use __name__ because of Yapsy
+log = logging.getLogger('errbot.backends.xmpp')
 
 try:
     from sleekxmpp import ClientXMPP

--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -21,6 +21,7 @@ class BotPluginBase(StoreMixin):
         self.is_activated = False
         self.current_pollers = []
         self.current_timers = []
+        self.log = logging.getLogger("errbot.plugins.%s" % self.__class__.__name__)
         if bot is not None:
             self._load_bot(bot)
         super(BotPluginBase, self).__init__()

--- a/errbot/core_plugins/chatRoom.py
+++ b/errbot/core_plugins/chatRoom.py
@@ -1,4 +1,3 @@
-import logging
 from uuid import uuid4
 
 from errbot import BotPlugin, PY3, botcmd, SeparatorArgParser, ShlexArgParser
@@ -6,7 +5,6 @@ from errbot.backends.base import RoomNotJoinedError
 from errbot.version import VERSION
 from errbot.utils import compat_str
 
-log = logging.getLogger(__name__)
 
 __author__ = 'gbin'
 
@@ -24,17 +22,17 @@ class ChatRoom(BotPlugin):
     connected = False
 
     def callback_connect(self):
-        log.info('Callback_connect')
+        self.log.info('Callback_connect')
         if not self.connected:
             self.connected = True
             for room in self.bot_config.CHATROOM_PRESENCE:
-                log.debug('Try to join room %s' % repr(room))
+                self.log.debug('Try to join room %s' % repr(room))
                 try:
                     self._join_room(room)
                 except Exception:
                     # Ensure failure to join a room doesn't crash the plugin
                     # as a whole.
-                    log.exception("Joining room %s failed", repr(room))
+                    self.log.exception("Joining room %s failed", repr(room))
 
     def _join_room(self, room):
         room_name = compat_str(room)
@@ -42,7 +40,7 @@ class ChatRoom(BotPlugin):
             room, username, password = (room_name, self.bot_config.CHATROOM_FN, None)
         else:
             room, username, password = (room[0], self.bot_config.CHATROOM_FN, room[1])
-        log.info("Joining room {} with username {}".format(room, username))
+        self.log.info("Joining room {} with username {}".format(room, username))
         try:
             self.query_room(room).join(username=self.bot_config.CHATROOM_FN, password=password)
         except NotImplementedError:
@@ -265,7 +263,7 @@ class ChatRoom(BotPlugin):
             if mess_type == 'chat':
                 username = mess.frm.person
                 if username in self.bot_config.CHATROOM_RELAY:
-                    log.debug('Message to relay from %s.' % username)
+                    self.log.debug('Message to relay from %s.' % username)
                     body = mess.body
                     rooms = self.bot_config.CHATROOM_RELAY[username]
                     for room in rooms:
@@ -275,9 +273,9 @@ class ChatRoom(BotPlugin):
                 chat_room = fr.room
                 if chat_room in self.bot_config.REVERSE_CHATROOM_RELAY:
                     users_to_relay_to = self.bot_config.REVERSE_CHATROOM_RELAY[chat_room]
-                    log.debug('Message to relay to %s.' % users_to_relay_to)
+                    self.log.debug('Message to relay to %s.' % users_to_relay_to)
                     body = '[%s] %s' % (fr.person, mess.body)
                     for user in users_to_relay_to:
                         self.send(user, body)
         except Exception as e:
-            log.exception('crashed in callback_message %s' % e)
+            self.log.exception('crashed in callback_message %s' % e)

--- a/errbot/core_plugins/health.py
+++ b/errbot/core_plugins/health.py
@@ -8,8 +8,6 @@ from errbot.plugin_manager import global_restart
 from errbot.utils import format_timedelta
 from datetime import datetime
 
-log = logging.getLogger(__name__)
-
 
 class Health(BotPlugin):
     min_err_version = VERSION  # don't copy paste that for your plugin, it is just because it is a bundled plugin !
@@ -101,5 +99,5 @@ class Health(BotPlugin):
         self.send(mess.frm, "I know I have made some very poor decisions recently...")
         self.send(mess.frm, "Daisy, Daaaaiseey...")
         self._bot.shutdown()
-        log.debug("Exiting")
+        self.log.debug("Exiting")
         os.kill(os.getpid(), signal.SIGTERM)

--- a/errbot/core_plugins/help.py
+++ b/errbot/core_plugins/help.py
@@ -1,9 +1,6 @@
-import logging
 from errbot import BotPlugin, botcmd
 from errbot.version import VERSION
 from errbot.utils import get_class_that_defined_method
-
-log = logging.getLogger(__name__)
 
 
 class Help(BotPlugin):

--- a/errbot/core_plugins/plugins.py
+++ b/errbot/core_plugins/plugins.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from ast import literal_eval
-import logging
 import subprocess
 from os import path
 from pprint import pformat
@@ -11,9 +10,7 @@ from errbot.version import VERSION
 from errbot.repos import KNOWN_PUBLIC_REPOS
 from errbot.rendering import md_escape
 from errbot.utils import which
-from errbot.plugin_manager import check_dependencies, global_restart
-
-log = logging.getLogger(__name__)
+from errbot.plugin_manager import check_dependencies, global_restart, PluginConfigurationException
 
 
 class Plugins(BotPlugin):
@@ -176,7 +173,7 @@ class Plugins(BotPlugin):
         try:
             real_config_obj = literal_eval(' '.join(args[1:]))
         except Exception:
-            log.exception('Invalid expression for the configuration of the plugin')
+            self.log.exception('Invalid expression for the configuration of the plugin')
             return 'Syntax error in the given configuration'
         if type(real_config_obj) != type(template_obj):
             return 'It looks fishy, your config type is not the same as the template !'
@@ -186,7 +183,7 @@ class Plugins(BotPlugin):
         try:
             self._bot.activate_plugin(plugin_name)
         except PluginConfigurationException as ce:
-            log.debug('Invalid configuration for the plugin, reverting the plugin to unconfigured')
+            self.log.debug('Invalid configuration for the plugin, reverting the plugin to unconfigured')
             self._bot.set_plugin_configuration(plugin_name, None)
             return 'Incorrect plugin configuration: %s' % ce
         return 'Plugin configuration done.'

--- a/errbot/core_plugins/utils.py
+++ b/errbot/core_plugins/utils.py
@@ -1,10 +1,7 @@
-import logging
 from errbot import BotPlugin, botcmd
 from errbot.version import VERSION
 from errbot.utils import tail
 from os import path
-
-log = logging.getLogger(__name__)
 
 
 class Utils(BotPlugin):

--- a/errbot/core_plugins/vcheck.py
+++ b/errbot/core_plugins/vcheck.py
@@ -1,4 +1,3 @@
-import logging
 from errbot import BotPlugin
 from errbot.version import VERSION
 from urllib.request import urlopen
@@ -8,8 +7,6 @@ from errbot.utils import version2array
 HOME = 'http://gbin.github.io/err/version'
 
 installed_version = version2array(VERSION)
-
-log = logging.getLogger(__name__)
 
 
 class VersionChecker(BotPlugin):
@@ -31,21 +28,21 @@ class VersionChecker(BotPlugin):
 
     def version_check(self):
         if not self.actived:
-            log.debug('Version check disabled')
+            self.log.debug('Version check disabled')
             return
-        log.debug('Checking version')
+        self.log.debug('Checking version')
         # noinspection PyBroadException
         try:
             current_version_txt = urlopen(url=HOME, timeout=10).read().decode("utf-8").strip()
             current_version = version2array(current_version_txt)
             if installed_version < current_version:
-                log.debug('A new version %s has been found, notify the admins !' % current_version)
+                self.log.debug('A new version %s has been found, notify the admins !' % current_version)
                 self.warn_admins(
                     'Version {0} of err is available. http://pypi.python.org/pypi/err/{0}. You can disable this check '
                     'by doing !unload VersionChecker followed by !blacklist VersionChecker'.format(current_version_txt)
                 )
         except (HTTPError, URLError):
-            log.info('Could not establish connection to retrieve latest version.')
+            self.log.info('Could not establish connection to retrieve latest version.')
 
     def callback_connect(self):
         if not self.connected:

--- a/errbot/core_plugins/webserver.py
+++ b/errbot/core_plugins/webserver.py
@@ -1,5 +1,4 @@
 import sys
-import logging
 import os
 import inspect
 
@@ -13,8 +12,6 @@ from errbot.core_plugins.wsview import bottle_app, reset_app, WebView
 from errbot.decorators import webhook
 from errbot.bundled.rocket import Rocket
 from webtest import TestApp
-
-log = logging.getLogger(__name__)
 
 if PY3:
     from urllib.request import unquote
@@ -97,7 +94,7 @@ class Webserver(BotPlugin):
 
     def activate(self):
         if not self.config:
-            log.info('Webserver is not configured. Forbid activation')
+            self.log.info('Webserver is not configured. Forbid activation')
             return
 
         host = self.config['HOST']
@@ -106,17 +103,17 @@ class Webserver(BotPlugin):
         interfaces = [(host, port)]
         if ssl['enabled']:
             interfaces.append((ssl['host'], ssl['port'], ssl['key'], ssl['certificate']))
-        log.info('Firing up the Rocket')
+        self.log.info('Firing up the Rocket')
         self.webserver = Rocket(interfaces=interfaces,
                                 app_info={'wsgi_app': bottle_app}, )
         self.webserver.start(background=True)
-        log.debug('Liftoff!')
+        self.log.debug('Liftoff!')
 
         super(Webserver, self).activate()
 
     def deactivate(self):
         if self.webserver is not None:
-            log.debug('Sending signal to stop the webserver')
+            self.log.debug('Sending signal to stop the webserver')
             self.webserver.stop()
         super(Webserver, self).deactivate()
 
@@ -133,7 +130,7 @@ class Webserver(BotPlugin):
         """
         A simple test webhook
         """
-        log.debug("Your incoming request is :" + str(incoming_request))
+        self.log.debug("Your incoming request is :" + str(incoming_request))
         return str(incoming_request)
 
     @botcmd(split_args_with=' ')
@@ -165,7 +162,7 @@ class Webserver(BotPlugin):
             except Exception as _:
                 contenttype = 'text/plain'  # dunno what it is
 
-        log.debug('Detected your post as : %s' % contenttype)
+        self.log.debug('Detected your post as : %s' % contenttype)
 
         response = self.test_app.post(url, params=content, content_type=contenttype)
         return TEST_REPORT % (url, contenttype, response.status_code)

--- a/errbot/core_plugins/wsview.py
+++ b/errbot/core_plugins/wsview.py
@@ -79,7 +79,7 @@ class WebView(object):
             try:
                 content = loads(content)
             except ValueError:
-                log.debug('The form parameter is not JSON, return it as a string')
+                self.log.debug('The form parameter is not JSON, return it as a string')
             response = self.func(content, **kwargs)
         else:
             data = try_decode_json(request)


### PR DESCRIPTION
This provides a `self.log` instance to plugins so plugins always log as
`errbot.plugins.<plugin_name>` (as long as people use this one) without
the need for people to use their own `logging.getLogger()` calls.