### PR TITLE
Added err-coffeetime to known repos

### DIFF
--- a/errbot/repos.py
+++ b/errbot/repos.py
@@ -134,4 +134,8 @@ KNOWN_PUBLIC_REPOS = {
         'https://github.com/charlesrg/err-stash.git',
         'Plugin to notify commits to Atlassian Stash Git repo to user or chatrooms.'
     ),
+    'err-coffeetime': (
+        'https://github.com/Ecno92/err-coffeetime.git',
+        'Tells which member of the group chat should bring the coffee.'
+    ),
 }


### PR DESCRIPTION
I just created a small plugin for fun. When ``!cofeetime`` is called in a group chat which the Err Bot is part of then Err will pick a random person who should bring the coffee. 