### PR TITLE
Added a config option for log file encoding.  The slack backend will …

### DIFF
--- a/errbot/main.py
+++ b/errbot/main.py
@@ -16,7 +16,8 @@ def setup_bot(backend_name, logger, config, restore=None):
     bot_config_defaults(config)
 
     if config.BOT_LOG_FILE:
-        hdlr = logging.FileHandler(config.BOT_LOG_FILE)
+        encoding = config.BOT_LOG_ENCODING if config.BOT_LOG_ENCODING else None
+        hdlr = logging.FileHandler(config.BOT_LOG_FILE, encoding=encoding)
         hdlr.setFormatter(logging.Formatter("%(asctime)s %(levelname)-8s %(name)-25s %(message)s"))
         logger.addHandler(hdlr)
 


### PR DESCRIPTION
…convert the markdown

into unicode chdaracters at times, causing the logger to spit out an exception when trying
to log those messages to the log file.

If you specify the encoding option when creating the log file handler, you can tell it to
write as UTF-8.