### PR TITLE
config: BOT_ADMINS also accepts a unique string

### DIFF
--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -47,6 +47,10 @@ class BotPluginBase(StoreMixin):
         For exemple you can access:
         self.bot_config.BOT_DATA_DIR
         """
+        # if BOT_ADMINS is just an unique string make it a tuple for backwards
+        # compatibility
+        if isinstance(self._bot.bot_config.BOT_ADMINS, str):
+            self._bot.bot_config.BOT_ADMINS = (self._bot.bot_config.BOT_ADMINS,)
         return self._bot.bot_config
 
     def init_storage(self):

--- a/tests/base_backend_tests.py
+++ b/tests/base_backend_tests.py
@@ -174,6 +174,16 @@ class TestBase(unittest.TestCase):
         self.assertEqual(str(resp.body), 'Response')
 
 
+class TestBaseConfig(unittest.TestCase):
+    def setUp(self):
+        self.dummy = DummyBackend(extra_config={'BOT_ADMINS': 'err@localhost'})
+
+    def test_BOT_ADMINS_unique_string(self):
+        dummy = self.dummy
+
+        self.assertEqual(dummy.bot_config.BOT_ADMINS, ('err@localhost',))
+
+
 class TestExecuteAndSend(unittest.TestCase):
     def setUp(self):
         self.dummy = DummyBackend()


### PR DESCRIPTION
* As noted in #461, in many cases an installation will only have one
  admin and therefore it does not make too much sense to force the
  BOT_ADMINS to be a tuple.

  This commit makes BOT_ADMINS also accept a unique string which is
  then converted to a single element tuple for backwards compatibility.

Signed-off-by: mr.Shu <mr@shu.io>

--------------------------------------------------------

Note that this should fix #461. 