### PR TITLE
setup.py: Fix pollution of dist-packages by tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include *.rst
 include errbot/*.svg
 include errbot/templates/*.md
 include errbot/core_plugins/templates/*.md
+prune tests

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
     setup(
         name="err",
         version=VERSION,
-        packages=find_packages(src_root),
+        packages=find_packages(src_root, exclude=['tests']),
         scripts=['scripts/err.py'],
 
         install_requires=deps,


### PR DESCRIPTION
* It seems that when installing err not only the errbot package is
  created but also a 'tests' package. This commit makes setup.py exclude
  that package, as described in http://stackoverflow.com/a/29978235

Signed-off-by: mr.Shu <mr@shu.io>