### PR TITLE
Create bot.all_commands, which unites commands and re_commands

### DIFF
--- a/errbot/backends/graphic.py
+++ b/errbot/backends/graphic.py
@@ -148,7 +148,7 @@ class ChatApplication(QtGui.QApplication):
         self.mainW.setWindowIcon(QtGui.QIcon(icon_path))
         vbox = QtGui.QVBoxLayout()
         help_label = QtGui.QLabel("CTRL+Space to autocomplete -- CTRL+Enter to send your message")
-        self.input = CommandBox(bot.cmd_history, bot.commands, bot.bot_config.BOT_PREFIX)
+        self.input = CommandBox(bot.cmd_history, bot.all_commands, bot.bot_config.BOT_PREFIX)
         self.output = QtWebKit.QWebView()
         self.output.settings().setUserStyleSheetUrl(QtCore.QUrl.fromLocalFile(css_path))
 
@@ -197,7 +197,7 @@ class GraphicBackend(TextBackend):
 
     def connect_callback(self):
         super().connect_callback()
-        self.app.update_commands(self.commands)
+        self.app.update_commands(self.all_commands)
 
     def send_command(self, text):
         self.app.new_message(text, False)

--- a/errbot/core_plugins/acls.py
+++ b/errbot/core_plugins/acls.py
@@ -82,7 +82,7 @@ class ACLS(BotPlugin):
 
         """
         self.log.info("Check if %s is admin only command." % cmd)
-        f = self._bot.commands[cmd] if cmd in self._bot.commands else self._bot.re_commands[cmd]
+        f = self._bot.all_commands[cmd]
 
         if f._err_command_admin_only:
             if msg.type == 'groupchat':

--- a/errbot/core_plugins/help.py
+++ b/errbot/core_plugins/help.py
@@ -33,7 +33,7 @@ class Help(BotPlugin):
         description = 'Available commands:\n'
 
         clazz_commands = {}
-        for (name, command) in self._bot.commands.items():
+        for (name, command) in self._bot.all_commands.items():
             clazz = get_class_that_defined_method(command)
             clazz = str.__module__ + '.' + clazz.__name__  # makes the fuul qualified name
             commands = clazz_commands.get(clazz, [])
@@ -81,7 +81,7 @@ class Help(BotPlugin):
             description = '### Available commands\n\n'
 
             clazz_commands = {}
-            for (name, command) in self._bot.commands.items():
+            for (name, command) in self._bot.all_commands.items():
                 clazz = get_class_that_defined_method(command)
                 commands = clazz_commands.get(clazz, [])
                 if not self.bot_config.HIDE_RESTRICTED_COMMANDS or may_access_command(name):
@@ -101,7 +101,7 @@ class Help(BotPlugin):
             usage += '\n\n'
         elif args in (clazz.__name__ for clazz in self._bot.get_command_classes()):
             # filter out the commands related to this class
-            commands = [(name, command) for (name, command) in self._bot.commands.items() if
+            commands = [(name, command) for (name, command) in self._bot.all_commands.items() if
                         get_class_that_defined_method(command).__name__ == args]
             description = '### Available commands for %s\n\n' % args
             usage += '\n'.join(sorted([
@@ -113,8 +113,8 @@ class Help(BotPlugin):
             ]))
         else:
             description = ''
-            if args in self._bot.commands:
-                usage = (self._bot.commands[args].__doc__ or
+            if args in self._bot.all_commands:
+                usage = (self._bot.all_commands[args].__doc__ or
                          'undocumented').strip()
             else:
                 usage = self.MSG_HELP_UNDEFINED_COMMAND

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -85,6 +85,13 @@ class ErrBot(Backend, BotPluginManager):
         else:
             self.bot_alt_prefixes = bot_config.BOT_ALT_PREFIXES
 
+    @property
+    def all_commands(self):
+        """Return both commands and re_commands together."""
+        newd = dict(**self.commands)
+        newd.update(self.re_commands)
+        return newd
+
     def _dispatch_to_plugins(self, method, *args, **kwargs):
         """
         Dispatch the given method to all active plugins.
@@ -384,7 +391,7 @@ class ErrBot(Backend, BotPluginManager):
             part1 = 'Command "%s" / "%s" not found.' % (cmd, full_cmd)
         else:
             part1 = 'Command "%s" not found.' % cmd
-        ununderscore_keys = [m.replace('_', ' ') for m in self.commands.keys()]
+        ununderscore_keys = [m.replace('_', ' ') for m in self.all_commands.keys()]
         matches = difflib.get_close_matches(cmd, ununderscore_keys)
         if full_cmd:
             matches.extend(difflib.get_close_matches(full_cmd, ununderscore_keys))
@@ -583,4 +590,5 @@ class ErrBot(Backend, BotPluginManager):
         return command.__doc__.replace('!', self.prefix)
 
     def get_command_classes(self):
-        return (get_class_that_defined_method(command) for command in self.commands.values())
+        return (get_class_that_defined_method(command)
+                for command in self.all_commands.values())

--- a/tests/commands_tests.py
+++ b/tests/commands_tests.py
@@ -9,12 +9,23 @@ from errbot.backends.test import FullStackTest
 
 
 class TestCommands(FullStackTest):
+
+    def setUp(self, *args, **kwargs):
+        kwargs['extra_plugin_dir'] = path.join(path.dirname(
+            path.realpath(__file__)), 'dummy_plugin')
+
+        super(TestCommands, self).setUp(*args, **kwargs)
+
     def test_root_help(self):
         self.assertCommand('!help', 'Available help')
 
     def test_help(self):
         self.assertCommand('!help Help', '!about')
         self.assertCommand('!help beurk', 'That command is not defined.')
+
+        # Ensure that help reports on re_commands.
+        self.assertCommand('!help foo', 'runs foo')  # Part of Dummy
+        self.assertCommand('!help re_foo', 'runs re_foo')  # Part of Dummy
 
     def test_about(self):
         self.assertCommand('!about', 'Err version')

--- a/tests/dummy_plugin/dummy.py
+++ b/tests/dummy_plugin/dummy.py
@@ -10,7 +10,7 @@ class DummyTest(BotPlugin):
         """This runs foo."""
         return 'bar'
 
-    @re_botcmd(pattern=ur"")
+    @re_botcmd(pattern=ur"plz dont match this")
     def re_foo(self, msg, match):
         """This runs re_foo."""
         return 'bar'

--- a/tests/dummy_plugin/dummy.py
+++ b/tests/dummy_plugin/dummy.py
@@ -1,4 +1,5 @@
-from errbot import BotPlugin, botcmd
+from __future__ import absolute_import
+from errbot import BotPlugin, botcmd, re_botcmd
 
 
 class DummyTest(BotPlugin):
@@ -6,4 +7,10 @@ class DummyTest(BotPlugin):
     """
     @botcmd
     def foo(self, msg, args):
+        """This runs foo."""
+        return 'bar'
+
+    @re_botcmd(pattern=ur"")
+    def re_foo(self, msg, match):
+        """This runs re_foo."""
         return 'bar'

--- a/tests/dummy_plugin/dummy.py
+++ b/tests/dummy_plugin/dummy.py
@@ -10,7 +10,7 @@ class DummyTest(BotPlugin):
         """This runs foo."""
         return 'bar'
 
-    @re_botcmd(pattern=ur"plz dont match this")
+    @re_botcmd(pattern=r"plz dont match this")
     def re_foo(self, msg, match):
         """This runs re_foo."""
         return 'bar'


### PR DESCRIPTION
references https://github.com/gbin/err/issues/486

Introduces `ErrBot.all_commands`, which is just a united `dict` consisting of both `commands` and `re_commands`. 

This prevents `!help`, the QT client, and some ACL operations from ignoring re_commands.