### PR TITLE
Allow @arg_botcmd decorated handlers to  yield results

### DIFF
--- a/errbot/__init__.py
+++ b/errbot/__init__.py
@@ -4,6 +4,7 @@ import logging
 import re
 import shlex
 import sys
+import inspect
 
 from .core_plugins.wsview import bottle_app, WebView
 from .utils import compat_str
@@ -170,7 +171,11 @@ def arg_botcmd(*args, hidden=False, name=None, admin_only=False,
                 parsed_args = err_command_parser.parse_args(args)
                 parsed_kwargs = vars(parsed_args)
 
-                return func(self, mess, **parsed_kwargs)
+                if inspect.isgeneratorfunction(func):
+                    for reply in func(self, mess, **parsed_kwargs):
+                        yield reply
+                else:
+                    yield func(self, mess, **parsed_kwargs)
 
             setattr(wrapper, '_err_command', True)
             setattr(wrapper, '_err_re_command', False)

--- a/tests/base_backend_tests.py
+++ b/tests/base_backend_tests.py
@@ -139,6 +139,11 @@ class DummyBackend(ErrBot):
 
     @arg_botcmd('--first-name', dest='first_name')
     @arg_botcmd('--last-name', dest='last_name')
+    def yields_first_name_last_name(self, mess, first_name=None, last_name=None):
+        yield "%s %s" % (first_name, last_name)
+
+    @arg_botcmd('--first-name', dest='first_name')
+    @arg_botcmd('--last-name', dest='last_name')
     def returns_first_name_last_name(self, mess, first_name=None, last_name=None):
         return "%s %s" % (first_name, last_name)
 
@@ -378,6 +383,14 @@ class BotCmds(unittest.TestCase):
         last_name = 'Bot'
         self.dummy.callback_message(
             self.makemessage("!returns_first_name_last_name --first-name=%s --last-name=%s" % (first_name, last_name))
+        )
+        self.assertEquals("%s %s" % (first_name, last_name), self.dummy.pop_message().body)
+
+    def test_arg_botcmd_yields_first_name_last_name(self):
+        first_name = 'Err'
+        last_name = 'Bot'
+        self.dummy.callback_message(
+            self.makemessage("!yields_first_name_last_name --first-name=%s --last-name=%s" % (first_name, last_name))
         )
         self.assertEquals("%s %s" % (first_name, last_name), self.dummy.pop_message().body)
 


### PR DESCRIPTION
When using the @arg_botcmd decorator yields don't work correctly. ErrBot returns "<generator object....>" rather than the actual text.

This is because @arg_botcmd is wrapping the handler in a new function and 2when _execute_and_send calls inspect.isgeneratorfunction on this wrapper it always gets a false, 
because its checking the wrapper not the underlying handler. 

This fix forces the wrapper to always be a generator which then works if the underlying 
handler is a generator or not.