### PR TITLE
Misc fixes: `!help multi word cmd` and slack markdown formatting

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -433,19 +433,24 @@ class SlackBackend(ErrBot):
             [str]
 
         """
-        fixed_format = body.startswith('```\n')  # hack to fix the formatting
-        parts = split_string_after(body, size_limit)
+        fixed_format = body.startswith('```')  # hack to fix the formatting
+        parts = list(split_string_after(body, size_limit))
 
-        for part in parts:
-            starts_with_code = part.startswith('```')
-
-            # If we're continuing a fixed block from the last part
-            if fixed_format and not starts_with_code:
-                part = '```\n' + part
-
+        if len(parts) == 1:
             # If we've got an open fixed block, close it out
-            if part.count('```') % 2 != 0:
-                part += '\n```\n'
+            if parts[0].count('```') % 2 != 0:
+                parts[0] += '\n```\n'
+        else:
+            for part in parts:
+                starts_with_code = part.startswith('```')
+
+                # If we're continuing a fixed block from the last part
+                if fixed_format and not starts_with_code:
+                    part = '```\n' + part
+
+                # If we've got an open fixed block, close it out
+                if part.count('```') % 2 != 0:
+                    part += '\n```\n'
 
         return parts
 

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -441,16 +441,16 @@ class SlackBackend(ErrBot):
             if parts[0].count('```') % 2 != 0:
                 parts[0] += '\n```\n'
         else:
-            for part in parts:
+            for i, part in enumerate(parts):
                 starts_with_code = part.startswith('```')
 
                 # If we're continuing a fixed block from the last part
                 if fixed_format and not starts_with_code:
-                    part = '```\n' + part
+                    parts[i] = '```\n' + part
 
                 # If we've got an open fixed block, close it out
                 if part.count('```') % 2 != 0:
-                    part += '\n```\n'
+                    parts[i] += '\n```\n'
 
         return parts
 

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -406,19 +406,48 @@ class SlackBackend(ErrBot):
             log.debug('Sending %s message to %s (%s)' % (mess.type, to_humanreadable, to_channel_id))
             body = self.md.convert(mess.body)
             log.debug('Message size: %d' % len(body))
-            fixed_format = body.startswith('```\n')  # hack to fix the formatting
-            for part in split_string_after(body, min(self.bot_config.MESSAGE_SIZE_LIMIT, SLACK_MESSAGE_LIMIT)):
-                if fixed_format:
-                    if not part.startswith('```\n'):
-                        part = '```\n' + part
-                    if not part.endswith('```') and not part.endswith('```\n'):
-                        part += '\n```\n'
+
+            limit = min(self.bot_config.MESSAGE_SIZE_LIMIT, SLACK_MESSAGE_LIMIT)
+            parts = self.prepare_message_body(body, limit)
+
+            for part in parts:
                 self.sc.rtm_send_message(to_channel_id, part)
         except Exception:
             log.exception(
                 "An exception occurred while trying to send the following message "
                 "to %s: %s" % (to_humanreadable, mess.body)
             )
+
+    @staticmethod
+    def prepare_message_body(body, size_limit):
+        """
+        Returns the parts of a message chunked and ready for sending.
+
+        This is a staticmethod for easier testing.
+
+        Args:
+            body (str)
+            size_limit (int): chunk the body into sizes capped at this maximum
+
+        Returns:
+            [str]
+
+        """
+        fixed_format = body.startswith('```\n')  # hack to fix the formatting
+        parts = split_string_after(body, size_limit)
+
+        for part in parts:
+            starts_with_code = part.startswith('```')
+
+            # If we're continuing a fixed block from the last part
+            if fixed_format and not starts_with_code:
+                part = '```\n' + part
+
+            # If we've got an open fixed block, close it out
+            if part.count('```') % 2 != 0:
+                part += '\n```\n'
+
+        return parts
 
     def build_identifier(self, txtrep):
         """ #channelname/username

--- a/errbot/core_plugins/help.py
+++ b/errbot/core_plugins/help.py
@@ -113,9 +113,11 @@ class Help(BotPlugin):
             ]))
         else:
             description = ''
-            if args in self._bot.all_commands:
-                usage = (self._bot.all_commands[args].__doc__ or
-                         'undocumented').strip()
+            all_commands = dict(self._bot.all_commands)
+            all_commands.merge(
+                {k.replace('_', ' '): v for k, v in all_commands.items()})
+            if args in all_commands:
+                usage = (all_commands[args].__doc__ or 'undocumented').strip()
             else:
                 usage = self.MSG_HELP_UNDEFINED_COMMAND
 

--- a/errbot/core_plugins/help.py
+++ b/errbot/core_plugins/help.py
@@ -114,7 +114,7 @@ class Help(BotPlugin):
         else:
             description = ''
             all_commands = dict(self._bot.all_commands)
-            all_commands.merge(
+            all_commands.update(
                 {k.replace('_', ' '): v for k, v in all_commands.items()})
             if args in all_commands:
                 usage = (all_commands[args].__doc__ or 'undocumented').strip()

--- a/tests/backend_tests/slack_tests.py
+++ b/tests/backend_tests/slack_tests.py
@@ -62,4 +62,3 @@ class SlackTests(unittest.TestCase):
         assert parts[0].endswith('```')
         assert parts[1].count('```') == 2
         assert parts[1].endswith('```\n')
-

--- a/tests/backend_tests/slack_tests.py
+++ b/tests/backend_tests/slack_tests.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 try:
     from errbot.backends import slack
-except Exception:
+except SystemExit:
     log.exception("Can't import backends.slack for testing")
     slack = None
 
@@ -53,3 +53,13 @@ class SlackTests(unittest.TestCase):
         test_body = """``` foobar """
         parts = self.slack.prepare_message_body(test_body, 10000)
         assert parts == [test_body + "\n```\n"]
+
+        test_body = """closed ``` foobar ``` not closed ```"""
+        # ---------------------------------^ 21st char
+        parts = self.slack.prepare_message_body(test_body, 21)
+        assert len(parts) == 2
+        assert parts[0].count('```') == 2
+        assert parts[0].endswith('```')
+        assert parts[1].count('```') == 2
+        assert parts[1].endswith('```\n')
+

--- a/tests/backend_tests/slack_tests.py
+++ b/tests/backend_tests/slack_tests.py
@@ -1,0 +1,55 @@
+import sys
+import unittest
+import logging
+import os
+from tempfile import mkdtemp
+
+from errbot.errBot import bot_config_defaults
+
+log = logging.getLogger(__name__)
+
+try:
+    from errbot.backends import slack
+except Exception:
+    log.exception("Can't import backends.slack for testing")
+    slack = None
+
+
+@unittest.skipIf(not slack, "package slackclient not installed")
+class SlackTests(unittest.TestCase):
+    def setUp(self):
+        # make up a config.
+        tempdir = mkdtemp()
+        # reset the config every time
+        sys.modules.pop('errbot.config-template', None)
+        __import__('errbot.config-template')
+        config = sys.modules['errbot.config-template']
+        bot_config_defaults(config)
+        config.BOT_DATA_DIR = tempdir
+        config.BOT_LOG_FILE = os.path.join(tempdir, 'log.txt')
+        config.BOT_EXTRA_PLUGIN_DIR = []
+        config.BOT_LOG_LEVEL = logging.DEBUG
+        config.BOT_IDENTITY = {'username': 'err@localhost', 'token': '___'}
+        config.BOT_ASYNC = False
+        config.BOT_PREFIX = '!'
+        config.CHATROOM_FN = 'blah'
+
+        self.slack = slack.SlackBackend(config)
+
+    def testPrepareMessageBody(self):
+        test_body = """
+        hey, this is some code:
+            ```
+            foobar
+            ```
+        """
+        parts = self.slack.prepare_message_body(test_body, 10000)
+        assert parts == [test_body]
+
+        test_body = """this block is unclosed: ``` foobar """
+        parts = self.slack.prepare_message_body(test_body, 10000)
+        assert parts == [test_body + "\n```\n"]
+
+        test_body = """``` foobar """
+        parts = self.slack.prepare_message_body(test_body, 10000)
+        assert parts == [test_body + "\n```\n"]

--- a/tests/commands_tests.py
+++ b/tests/commands_tests.py
@@ -26,6 +26,7 @@ class TestCommands(FullStackTest):
         # Ensure that help reports on re_commands.
         self.assertCommand('!help foo', 'runs foo')  # Part of Dummy
         self.assertCommand('!help re_foo', 'runs re_foo')  # Part of Dummy
+        self.assertCommand('!help re foo', 'runs re_foo')  # Part of Dummy
 
     def test_about(self):
         self.assertCommand('!about', 'Err version')


### PR DESCRIPTION
Hey guys! Some more small fixes.

0. `!help multi_word_cmd` works, but `!help multi word cmd` doesn't -- I think it should!
0. Markdown formatting for Slack is kind of odd; e.g. the output of `!whoami` looks like this (notice the trailing backticks):
![selection_023](https://cloud.githubusercontent.com/assets/73197/10327663/2a29e3de-6c5f-11e5-8102-e9b83244c725.png)

This branch contains fixes (and tests) for both. I'll squash when you think the changes are ready for merge.
