### PR TITLE
Changes order of development deps in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,8 +59,8 @@ else:
 deps += ['mock',
          'nose',
          'pep8',
-         'pytest',
          'pytest-xdist',
+         'pytest',
          'PyOpenSSL']
 
 if not ON_WINDOWS:


### PR DESCRIPTION
Without this change, a `python setup.py develop` in a new virtualenv fails to
finish with an error: `The 'pytest' distribution was not found and is
required`.

This is due to a bug/feature in setuptools:

https://bitbucket.org/pypa/setuptools/issues/196/tests_require-pytest-pytest-cov-breaks

Essentially, `pytest-xdist` is being matched as the `xdist` version of pytest
instead of recognizing it as a separate package; as a result, `pytest-xdist` is
fulfilling the role of `pyest`, when in reality it does not actually provide
that functionality.

The current workaround is to change the order of operations so that the
`pytest` package is the last to be installed after any other `pytest-*`
packages have been processed.