### PR TITLE
added prereq for hipchat backend

### DIFF
--- a/docs/user_guide/setup.rst
+++ b/docs/user_guide/setup.rst
@@ -44,6 +44,10 @@ For the IRC backend, you must install::
 
     irc
 
+For the Hipchat backend you must install::
+
+    hypchat
+
 Configuration
 -------------
 


### PR DESCRIPTION
added prereq for hipchat backend.  In Python 3.4 it's more apparent, but in 2.7 it was just a cryptic "unable to find backend hipchat"