### PR TITLE
Slack changes to facilitate bot interaction

### DIFF
--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -40,18 +40,27 @@ class Message(object):
     make sense in the context of other back-ends.
     """
 
-    def __init__(self, body='', type_='chat', frm=None, to=None, delayed=False):
+    def __init__(self,
+                 body='',
+                 type_='chat',
+                 frm=None,
+                 to=None,
+                 delayed=False,
+                 extras=None):
         """
         :param body:
             The plaintext body of the message.
         :param type_:
             The type of message (generally one of either 'chat' or 'groupchat').
+        :param extras:
+            Extra data attached by a backend
         """
         self._body = compat_str(body)
         self._type = type_
         self._from = frm
         self._to = to
         self._delayed = delayed
+        self._extras = extras or dict()
 
     @property
     def to(self):
@@ -144,6 +153,10 @@ class Message(object):
     @delayed.setter
     def delayed(self, delayed):
         self._delayed = delayed
+
+    @property
+    def extras(self):
+        return self._extras
 
     def __str__(self):
         return self._body

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -3,6 +3,7 @@ import logging
 import re
 import time
 import sys
+import pprint
 
 from errbot.backends import DeprecationBridgeIdentifier
 from errbot.backends.base import Message, Presence, ONLINE, AWAY, MUCRoom, RoomError, RoomDoesNotExistError, \
@@ -330,8 +331,11 @@ class SlackBackend(ErrBot):
 
         text = re.sub("<[^>]*>", self.remove_angle_brackets_from_uris, text)
 
+        log.debug("Saw an event: %s" % pprint.pformat(event))
+
         msg = SlackMessage(
-            text, type_=message_type, attachments=event['attachments'])
+            text, type_=message_type, attachments=event.get('attachments'))
+
         if message_type == 'chat':
             msg.frm = SlackIdentifier(self.sc, user, event['channel'])
             msg.to = SlackIdentifier(self.sc, self.username_to_userid(self.sc.server.username),

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -307,10 +307,10 @@ class SlackBackend(ErrBot):
 
         if 'message' in event:
             text = event['message']['text']
-            user = event['message']['user']
+            user = event['message'].get('user', 'Bot')
         else:
             text = event['text']
-            user = event['user']
+            user = event.get('user', 'Bot')
 
         text = re.sub("<[^>]*>", self.remove_angle_brackets_from_uris, text)
 

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -312,6 +312,8 @@ class SlackBackend(ErrBot):
             text = event['text']
             user = event.get('user', 'Uxxx')
 
+        log.info("Event: %s" % event)
+        log.info("Text: %s" % text)
         text = re.sub("<[^>]*>", self.remove_angle_brackets_from_uris, text)
 
         msg = Message(text, type_=message_type)
@@ -324,6 +326,7 @@ class SlackBackend(ErrBot):
             msg.to = SlackMUCOccupant(self.sc, self.username_to_userid(self.sc.server.username),
                                       event['channel'])
 
+        log.info("Callback message: %s" % msg.__dict__)
         self.callback_message(msg)
 
     def userid_to_username(self, id_):

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -307,10 +307,10 @@ class SlackBackend(ErrBot):
 
         if 'message' in event:
             text = event['message']['text']
-            user = event['message'].get('user', 'Bot')
+            user = event['message'].get('user', 'Uxxx')
         else:
             text = event['text']
-            user = event.get('user', 'Bot')
+            user = event.get('user', 'Uxxx')
 
         text = re.sub("<[^>]*>", self.remove_angle_brackets_from_uris, text)
 

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -156,11 +156,6 @@ class ErrBot(Backend, BotPluginManager):
         log.debug("*** type = %s" % type_)
         log.debug("*** text = %s" % text)
 
-        # If a message format is not supported (eg. encrypted),
-        # txt will be None
-        if not text:
-            return False
-
         surpress_cmd_not_found = False
 
         prefixed = False  # Keeps track whether text was prefixed with a bot prefix

--- a/tests/backend_tests/slack_tests.py
+++ b/tests/backend_tests/slack_tests.py
@@ -36,6 +36,14 @@ class SlackTests(unittest.TestCase):
 
         self.slack = slack.SlackBackend(config)
 
+    def testSlackMessage(self):
+        m = slack.SlackMessage(
+            'foobar', type_='groupchat', attachments={1:1})
+        assert m.attachments == {1:1}
+
+        m = slack.SlackMessage('foobar2', type_='groupchat')
+        assert m.attachments is None
+
     def testPrepareMessageBody(self):
         test_body = """
         hey, this is some code:

--- a/tests/backend_tests/slack_tests.py
+++ b/tests/backend_tests/slack_tests.py
@@ -38,8 +38,8 @@ class SlackTests(unittest.TestCase):
 
     def testSlackMessage(self):
         m = slack.SlackMessage(
-            'foobar', type_='groupchat', attachments={1:1})
-        assert m.attachments == {1:1}
+            'foobar', type_='groupchat', attachments={1: 1})
+        assert m.attachments == {1: 1}
 
         m = slack.SlackMessage('foobar2', type_='groupchat')
         assert m.attachments is None


### PR DESCRIPTION
We've got a monitoring bot that posts certain alerts into our slack (via webhook) when various metrics break certain thresholds. We want our errbot to grab the graphs associated with these metrics and paste them in; this involves reading attachments from bot users in Slack.

![selection_027](https://cloud.githubusercontent.com/assets/73197/10407315/2973351c-6e9e-11e5-89d7-ee31475dbba1.png)

(riemann is a webhook bot, Scruffy is an errbot)

This PR includes the changes necessary to accomplish the above:

- Slack backend no longer errors on messages from bot users
- The `SlackMessage` class exposes `attachments` to plugin writers
- Messages with blank `text` fields (like those sent from the bot in this case) are no longer ignored
- Markdown rendering is made optional

cc @cyc @greglook