### PR TITLE
[slack] Fix accidental naming collision (Slack.process_message)

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -221,7 +221,7 @@ class SlackBackend(ErrBot):
             try:
                 while True:
                     for message in self.sc.rtm_read():
-                        self.process_message(message)
+                        self._dispatch_slack_message(message)
                     time.sleep(1)
             except KeyboardInterrupt:
                 log.info("Interrupt received, shutting down..")
@@ -234,7 +234,7 @@ class SlackBackend(ErrBot):
         else:
             raise Exception('Connection failed, invalid token ?')
 
-    def process_message(self, message):
+    def _dispatch_slack_message(self, message):
         """
         Process an incoming message from slack.
 

--- a/tests/backend_tests/slack_tests.py
+++ b/tests/backend_tests/slack_tests.py
@@ -74,7 +74,7 @@ class SlackTests(unittest.TestCase):
             'attachments': [attachment]
         }
 
-        self.slack.process_message(bot_msg)
+        self.slack._dispatch_slack_message(bot_msg)
         msg = self.slack.test_msgs.pop()
 
         self.assertEqual(msg.extras['attachments'], [attachment])


### PR DESCRIPTION
Oops! I inadvertently cause a method-name collision in https://github.com/gbin/err/pull/498. This fixes it.

My apologies.