### PR TITLE
Fix BotPlugin.rooms() trying to call a set.

### DIFF
--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -372,7 +372,7 @@ class BotPlugin(BotPluginBase):
         """
         The list of rooms the bot is currently in.
         """
-        return self._bot.rooms()
+        return self._bot.rooms
 
     def query_room(self, room):
         """


### PR DESCRIPTION
At least for the HipChat backend on version 3.0.0, the errBot.rooms attribute is a set of rooms, rather than a getter method; this is in conflict with the documentation, and I'm unsure which is right.  If this is an issue just with this specific type of bot, I can try to fix that instead.