### PR TITLE
Respect optional prefix with re_botcmd

### DIFF
--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -229,7 +229,7 @@ class ErrBot(Backend, BotPluginManager):
         # Try to match one of the regex commands if the regular commands produced no match
         matched_on_re_command = False
         if not cmd:
-            if prefixed:
+            if prefixed or (type_ == "chat" and self.bot_config.BOT_PREFIX_OPTIONAL_ON_CHAT):
                 commands = self.re_commands
             else:
                 commands = {k: self.re_commands[k] for k in self.re_commands

--- a/tests/commands_tests.py
+++ b/tests/commands_tests.py
@@ -246,3 +246,31 @@ class TestCommands(FullStackTest):
 
         self.bot.push_message("!status plugins")
         self.assertIn("A      │ ChatRoom", self.bot.pop_message())
+
+    def test_optional_prefix(self):
+        # Let's not leave any side effects
+        prefix_optional = self.bot.bot_config.BOT_PREFIX_OPTIONAL_ON_CHAT
+
+        self.bot.bot_config.BOT_PREFIX_OPTIONAL_ON_CHAT = False
+        self.assertCommand('!status', 'Yes I am alive')
+
+        self.bot.bot_config.BOT_PREFIX_OPTIONAL_ON_CHAT = True
+        self.assertCommand('!status', 'Yes I am alive')
+        self.assertCommand('status', 'Yes I am alive')
+
+        # Now reset our state so we don't bork the other tests
+        self.bot.bot_config.BOT_PREFIX_OPTIONAL_ON_CHAT = prefix_optional
+
+    def test_optional_prefix_re_cmd(self):
+        # Let's not leave any side effects
+        prefix_optional = self.bot.bot_config.BOT_PREFIX_OPTIONAL_ON_CHAT
+
+        self.bot.bot_config.BOT_PREFIX_OPTIONAL_ON_CHAT = False
+        self.assertCommand('!plz dont match this', 'bar')
+
+        self.bot.bot_config.BOT_PREFIX_OPTIONAL_ON_CHAT = True
+        self.assertCommand('!plz dont match this', 'bar')
+        self.assertCommand('plz dont match this', 'bar')
+
+        # Now reset our state so we don't bork the other tests
+        self.bot.bot_config.BOT_PREFIX_OPTIONAL_ON_CHAT = prefix_optional


### PR DESCRIPTION
When the setting BOT_PREFIX_OPTIONAL_ON_CHAT is set to True, plugin commands decorated with the re_botcmd decorator would ignore it and still require the bot's prefix; this fixes that by adding an additional check when testing re_botcmds.

This resolves gbin/err#504.