### PR TITLE
WIP: Redis implemented and tested

### DIFF
--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -25,6 +25,10 @@ class BotPluginBase(StoreMixin):
             self._load_bot(bot)
         super(BotPluginBase, self).__init__()
 
+        # This may be set by the owning ErrBot instance as a
+        # `storage.RedisStorage` if redis is properly configured.
+        self.redis = None
+
     def _load_bot(self, bot):
         """ This should be eventually moved back to __init__ once plugin will forward correctly their params.
         """

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -294,3 +294,11 @@ REVERSE_CHATROOM_RELAY = {}
 
 # Disables table borders (IRC only for now). You can reenable them switching that to  False
 # COMPACT_OUTPUT = True
+
+##########################################################################
+# Redis configuration                                                    #
+##########################################################################
+
+# REDIS_HOST = 'localhost'
+# REDIS_PORT = 6379
+# REDIS_DB = 0

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -27,35 +27,33 @@ from .utils import (split_string_after,
 from .streaming import Tee
 from .plugin_manager import BotPluginManager
 from .templating import tenv
+from errbot import storage
 
 log = logging.getLogger(__name__)
 
 
 def bot_config_defaults(config):
-    if not hasattr(config, 'ACCESS_CONTROLS_DEFAULT'):
-        config.ACCESS_CONTROLS_DEFAULT = {}
-    if not hasattr(config, 'ACCESS_CONTROLS'):
-        config.ACCESS_CONTROLS = {}
-    if not hasattr(config, 'HIDE_RESTRICTED_COMMANDS'):
-        config.HIDE_RESTRICTED_COMMANDS = False
-    if not hasattr(config, 'HIDE_RESTRICTED_ACCESS'):
-        config.HIDE_RESTRICTED_ACCESS = False
-    if not hasattr(config, 'BOT_PREFIX_OPTIONAL_ON_CHAT'):
-        config.BOT_PREFIX_OPTIONAL_ON_CHAT = False
-    if not hasattr(config, 'BOT_ALT_PREFIXES'):
-        config.BOT_ALT_PREFIXES = ()
-    if not hasattr(config, 'BOT_ALT_PREFIX_SEPARATORS'):
-        config.BOT_ALT_PREFIX_SEPARATORS = ()
-    if not hasattr(config, 'BOT_ALT_PREFIX_CASEINSENSITIVE'):
-        config.BOT_ALT_PREFIX_CASEINSENSITIVE = False
-    if not hasattr(config, 'DIVERT_TO_PRIVATE'):
-        config.DIVERT_TO_PRIVATE = ()
-    if not hasattr(config, 'MESSAGE_SIZE_LIMIT'):
-        config.MESSAGE_SIZE_LIMIT = 10000  # Corresponds with what HipChat accepts
-    if not hasattr(config, 'GROUPCHAT_NICK_PREFIXED'):
-        config.GROUPCHAT_NICK_PREFIXED = False
-    if not hasattr(config, 'AUTOINSTALL_DEPS'):
-        config.AUTOINSTALL_DEPS = False
+    name_to_default_val = {
+        'ACCESS_CONTROLS_DEFAULT': {},
+        'ACCESS_CONTROLS': {},
+        'HIDE_RESTRICTED_COMMANDS': False,
+        'HIDE_RESTRICTED_ACCESS': False,
+        'BOT_PREFIX_OPTIONAL_ON_CHAT': False,
+        'BOT_ALT_PREFIXES': (),
+        'BOT_ALT_PREFIX_SEPARATORS': (),
+        'BOT_ALT_PREFIX_CASEINSENSITIVE': False,
+        'DIVERT_TO_PRIVATE': (),
+        'MESSAGE_SIZE_LIMIT': 10000,  # Corresponds with what HipChat accepts
+        'GROUPCHAT_NICK_PREFIXED': False,
+        'AUTOINSTALL_DEPS': False,
+        'REDIS_HOST': None,
+        'REDIS_PORT': None,
+        'REDIS_DB': None,
+    }
+
+    for (name, default) in name_to_default_val.items():
+        if not hasattr(config, name):
+            setattr(config, name, default)
 
 
 class ErrBot(Backend, BotPluginManager):
@@ -66,7 +64,7 @@ class ErrBot(Backend, BotPluginManager):
     MSG_UNKNOWN_COMMAND = 'Unknown command: "%(command)s". '
     startup_time = datetime.now()
 
-    def __init__(self, bot_config):
+    def __init__(self, bot_config, get_redis_client=storage.get_redis_client):
         log.debug("ErrBot init.")
         super(ErrBot, self).__init__(bot_config)
         self._init_plugin_manager(bot_config)
@@ -84,6 +82,24 @@ class ErrBot(Backend, BotPluginManager):
             self.bot_alt_prefixes = tuple(prefix.lower() for prefix in bot_config.BOT_ALT_PREFIXES)
         else:
             self.bot_alt_prefixes = bot_config.BOT_ALT_PREFIXES
+
+        self.redis_client = None
+        has_cfg = lambda c: getattr(self.bot_config, c, None) is not None
+
+        if has_cfg('REDIS_HOST') and \
+                has_cfg('REDIS_PORT') and \
+                has_cfg('REDIS_DB'):
+            self.redis_client = get_redis_client(
+                self.bot_config.REDIS_HOST,
+                self.bot_config.REDIS_PORT,
+                self.bot_config.REDIS_DB)
+        else:
+            log.info(
+                "Couldn't enable redis; host/port/db: %s" %
+                (str(tuple(
+                    self.bot_config.REDIS_HOST,
+                    self.bot_config.REDIS_PORT,
+                    self.bot_config.REDIS_DB))))
 
     @property
     def all_commands(self):
@@ -404,6 +420,11 @@ class ErrBot(Backend, BotPluginManager):
 
     def inject_commands_from(self, instance_to_inject):
         classname = instance_to_inject.__class__.__name__
+
+        if self.redis_client and not instance_to_inject.redis:
+            instance_to_inject.redis = storage.RedisStore.for_plugin(
+                self.redis_client, instance_to_inject)
+
         for name, value in inspect.getmembers(instance_to_inject, inspect.ismethod):
             if getattr(value, '_err_command', False):
                 commands = self.re_commands if getattr(value, '_err_re_command') else self.commands

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -96,10 +96,10 @@ class ErrBot(Backend, BotPluginManager):
         else:
             log.info(
                 "Couldn't enable redis; host/port/db: %s" %
-                (str(tuple(
+                (str([
                     self.bot_config.REDIS_HOST,
                     self.bot_config.REDIS_PORT,
-                    self.bot_config.REDIS_DB))))
+                    self.bot_config.REDIS_DB])))
 
     @property
     def all_commands(self):

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -84,7 +84,9 @@ class ErrBot(Backend, BotPluginManager):
             self.bot_alt_prefixes = bot_config.BOT_ALT_PREFIXES
 
         self.redis_client = None
-        has_cfg = lambda c: getattr(self.bot_config, c, None) is not None
+
+        def has_cfg(c):
+            return getattr(self.bot_config, c, None) is not None
 
         if has_cfg('REDIS_HOST') and \
                 has_cfg('REDIS_PORT') and \

--- a/errbot/storage.py
+++ b/errbot/storage.py
@@ -1,9 +1,16 @@
 from collections import MutableMapping
 import logging
 import shelve
+import json
 
 from .utils import PY2
 log = logging.getLogger(__name__)
+
+try:
+    import redis
+except ImportError:
+    log.debug("Unable to load `redis`.")
+    redis = None
 
 
 class StoreException(Exception):
@@ -67,3 +74,83 @@ class StoreMixin(MutableMapping):
     def __iter__(self):
         for i in self.shelf:
             yield i
+
+
+class RedisStore():
+    """
+    A storage mechanism backed by Redis, namespaced per-plugin by a key.
+
+    """
+    def __init__(self, redis_client, key_prefix):
+        """
+        Args:
+            redis_client (redis.Redis)
+            key_prefix (str):
+
+        """
+        self.client = redis_client
+        self.key_prefix = key_prefix
+
+    @classmethod
+    def for_plugin(cls, redis_client, plugin):
+        """
+        Instantiate a `RedisStore` instance for use by a `BotPlugin` instance.
+
+        """
+        return cls(redis_client, "%s::" % plugin.__class__.__name__)
+
+    def get(self, key):
+        """
+        Args:
+            key (str)
+
+        Returns:
+            object. deserialized from str by json.loads
+
+        """
+        pkey = self.key_prefix + key
+        got = self.client.get(pkey)
+
+        if not got:
+            return None
+
+        return json.loads(self._py3_compat_decode(got))
+
+    def set(self, key, val, ttl=None):
+        """
+        Args:
+            key (str)
+            val (object): must be jsonable
+
+        Kwargs:
+            ttl (int): in seconds
+
+        Returns:
+            bool. if set
+
+        """
+        pkey = self.key_prefix + key
+        try:
+            ttl and int(ttl)
+        except Exception:
+            raise ValueError("ttl must be int-like or None")
+
+        return self.client.set(pkey, json.dumps(val), ex=ttl)
+
+    def _py3_compat_decode(self, item_out_of_redis):
+        """Py3 redis returns bytes, so we must handle the decode."""
+        if not isinstance(item_out_of_redis, str):
+            return item_out_of_redis.decode('utf-8')
+        return item_out_of_redis
+
+
+def get_redis_client(host, port, db):
+    """
+    If we can import redis, return a client. If not, return None.
+
+    """
+    if not redis:
+        log.info("Can't use redis -- we don't have `redis` installed")
+        return None
+
+    return redis.Redis(host=host, port=port, db=db)


### PR DESCRIPTION
I've added a tested and working proof of concept for using Redis storage. The implementation is fairly simple; you provide redis config data in the `config.py`, then `ErrBot` injects a wrapped redis client into each plugin instance. The wrapped client automatically namespaces based on the plugin classname.

Obviously there's a bit more polish to do here in terms of doc, but I can start on that if you like the approach in general.