### PR TITLE
Fix warn_admins() on Telegram

### DIFF
--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -331,5 +331,6 @@ def compat_str(s):
     if isinstance(s, str):
         return s
     elif isinstance(s, bytes):
-        return s.decode()
-    return None
+        return s.decode('utf-8')
+    else:
+        return str(s)


### PR DESCRIPTION
Telegram uses numbers to denote people on the network, so admin
configuration uses integers in `config.py`.

This currently breaks the `warn_admins()` function (and possibly other
rare corner cases) with the following traceback:

```
2015-10-25 20:24:13,002 ERROR    errbot.backends.base      Exception occurred in serve_once:
Traceback (most recent call last):
  File "/srv/errbot/repository/errbot/backends/base.py", line 579, in serve_forever
    if self.serve_once():
  File "/srv/errbot/repository/errbot/backends/telegram.py", line 149, in serve_once
    self.connect_callback()
  File "/srv/errbot/repository/errbot/errBot.py", line 583, in connect_callback
    loading_errors = self.activate_non_started_plugins()
  File "/srv/errbot/repository/errbot/plugin_manager.py", line 379, in activate_non_started_plugins
    self.warn_admins(errors)
  File "/srv/errbot/repository/errbot/errBot.py", line 512, in warn_admins
    self.send(admin, warning)
  File "/srv/errbot/repository/errbot/errBot.py", line 135, in send
    mess.to = user
  File "/srv/errbot/repository/errbot/backends/base.py", line 89, in to
    % (to, to.__class__))
Exception: `to` not an Identifier as it misses the "person" property. `to` : 123669037 (<class 'int'>)
```

This happens because a utility function only expects `bytes` or `str`
types right now. With this change, the value is cast to `str` when it is
neither, fixing the issue.