### PR TITLE
Re-fix warn_admins() on Telegram

### DIFF
--- a/errbot/__init__.py
+++ b/errbot/__init__.py
@@ -236,9 +236,8 @@ def webhook(*args, **kwargs):
         func._err_webhook_form_param = form_param
         func._err_webhook_raw = raw
         return func
-    first = compat_str(args[0])
-    if first is not None:
-        return lambda method: decorate(method, first, **kwargs)
+    if isinstance(args[0], (str, bytes)):
+        return lambda method: decorate(method, compat_str(args[0]), **kwargs)
     return decorate(args[0], '/' + args[0].__name__ + '/', **kwargs)
 
 

--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -338,5 +338,6 @@ def compat_str(s):
     if isinstance(s, str):
         return s
     elif isinstance(s, bytes):
-        return s.decode()
-    return None
+        return s.decode('utf-8')
+    else:
+        return str(s)


### PR DESCRIPTION
It appears the webhook decorator was relying on the quirk of compat_str
returning None for non-string objects. I think that is undesirable
behavior so made the webhook decorator smarter, so the same changes as
in the original PR (#514) can be applied to compat_str again.