### PR TITLE
Various arg_botcmd improvements

### DIFF
--- a/errbot/__init__.py
+++ b/errbot/__init__.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 import argparse
 from functools import wraps
 import logging
@@ -194,7 +196,10 @@ def arg_botcmd(*args, hidden=False, name=None, admin_only=False,
             @wraps(func)
             def wrapper(self, mess, args):
 
-                args = shlex.split(args)
+                # Some clients automatically convert consecutive dashes into a fancy
+                # hyphen, which breaks long-form arguments. Undo this conversion to
+                # provide a better user experience.
+                args = shlex.split(args.replace('—', '--'))
                 try:
                     parsed_args = err_command_parser.parse_args(args)
                 except ArgumentParseError as e:

--- a/tests/base_backend_tests.py
+++ b/tests/base_backend_tests.py
@@ -419,6 +419,14 @@ class BotCmds(unittest.TestCase):
             self.dummy.pop_message().body
         )
 
+    def test_arg_botcmd_undoes_fancy_unicode_dash_conversion(self):
+        first_name = 'Err'
+        last_name = 'Bot'
+        self.dummy.callback_message(
+            self.makemessage("!returns_first_name_last_name —first-name=%s —last-name=%s" % (first_name, last_name))
+        )
+        self.assertEquals("%s %s" % (first_name, last_name), self.dummy.pop_message().body)
+
     def test_access_controls(self):
         tests = [
             dict(

--- a/tests/base_backend_tests.py
+++ b/tests/base_backend_tests.py
@@ -24,9 +24,9 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 class DummyBackend(ErrBot):
-    outgoing_message_queue = Queue()
 
     def __init__(self, extra_config=None):
+        self.outgoing_message_queue = Queue()
         if extra_config is None:
             extra_config = {}
         # make up a config.

--- a/tests/base_backend_tests.py
+++ b/tests/base_backend_tests.py
@@ -147,6 +147,11 @@ class DummyBackend(ErrBot):
     def returns_first_name_last_name(self, mess, first_name=None, last_name=None):
         return "%s %s" % (first_name, last_name)
 
+    @arg_botcmd('--first-name', dest='first_name')
+    @arg_botcmd('--last-name', dest='last_name', unpack_args=False)
+    def returns_first_name_last_name_without_unpacking(self, mess, args):
+        return "%s %s" % (args.first_name, args.last_name)
+
     @arg_botcmd('value', type=str)
     @arg_botcmd('--count', dest='count', type=int)
     def returns_value_repeated_count_times(self, mess, value=None, count=None):
@@ -424,6 +429,15 @@ class BotCmds(unittest.TestCase):
         last_name = 'Bot'
         self.dummy.callback_message(
             self.makemessage("!returns_first_name_last_name —first-name=%s —last-name=%s" % (first_name, last_name))
+        )
+        self.assertEquals("%s %s" % (first_name, last_name), self.dummy.pop_message().body)
+
+    def test_arg_botcmd_without_argument_unpacking(self):
+        first_name = 'Err'
+        last_name = 'Bot'
+        self.dummy.callback_message(
+            self.makemessage("!returns_first_name_last_name_without_unpacking --first-name=%s --last-name=%s"
+                             % (first_name, last_name))
         )
         self.assertEquals("%s %s" % (first_name, last_name), self.dummy.pop_message().body)
 

--- a/tests/base_backend_tests.py
+++ b/tests/base_backend_tests.py
@@ -402,6 +402,23 @@ class BotCmds(unittest.TestCase):
         )
         self.assertEquals(value * count, self.dummy.pop_message().body)
 
+    def test_arg_botcmd_doesnt_raise_systemerror(self):
+        self.dummy.callback_message(self.makemessage("!returns_first_name_last_name --invalid-parameter"))
+
+    def test_arg_botcdm_returns_errors_as_chat(self):
+        self.dummy.callback_message(self.makemessage("!returns_first_name_last_name --invalid-parameter"))
+        self.assertIn(
+            "I'm sorry, I couldn't parse that; unrecognized arguments: --invalid-parameter",
+            self.dummy.pop_message().body
+        )
+
+    def test_arg_botcmd_returns_help_message_as_chat(self):
+        self.dummy.callback_message(self.makemessage("!returns_first_name_last_name --help"))
+        self.assertIn(
+            "usage: returns_first_name_last_name [-h] [--last-name LAST_NAME]",
+            self.dummy.pop_message().body
+        )
+
     def test_access_controls(self):
         tests = [
             dict(


### PR DESCRIPTION
This PR introduces a number of enhancements to how the `arg_botcmd` decorator works:

*  Ensure arg_botcmd error and help output goes into chat and avoid raising SystemExit

	By default, argparse will print errors, usage and help text directly to
	stdout/stderr. It will also raise SystemExit to make the program stop
	with an appropriate error code.

	While this is appropriate for a CLI program, it is horrible for Err. The
	SystemExit causes some strange behaviour where it doesn't make the bot
	exit, but does prevent some processing (!restart no longer works, for
	example) and the printing to stdout/stderr means you get no feedback
	when issuing commands with incorrect arguments.

	With these changes, all this output is nicely returned to the user,
	instead.

* Ensure the command name is used in the usage as well, instead of the
default `sys.arv[0]` which resulted in one of `err.py`, `errbot` or
`run_tests.py`.

* Convert — to -- when parsing arg_botcmds

	Some clients (looking at you, Telegram) convert certain ASCII character
	combinations to nicer-looking unicode representations, which break the
	argument parser. Account for this and undo the conversion to avoid user
	frustration.

*  Make "argument unpacking" on arg_botcmd optional

	With this change it becomes possible to define a single `args` argument
	to hold all the argparser arguments, removing the need to define them in
	the function signature itself.

	This is useful especially on commands with lots of argument flags, as
	otherwise you have to make sure you define all your arguments in just
	the right order, which is very error prone.
