### PR TITLE
Added a comprehensive md escaping.

### DIFF
--- a/errbot/rendering/__init__.py
+++ b/errbot/rendering/__init__.py
@@ -9,6 +9,12 @@ ATTR_RE = re.compile(AttrListTreeprocessor.BASE_RE)
 # Here are few helpers to simplify the conversion from markdown to various
 # backend formats.
 
+_md_escape_re = re.compile('|'.join(re.escape(c) for c in Markdown.ESCAPED_CHARS))
+
+
+def _md_escape_trans(match):
+    return '\\' + match.group(0)
+
 
 def ansi():
     """This makes a converter from markdown to ansi (console) format.
@@ -86,6 +92,4 @@ def md_escape(txt):
     """ Call this if you want to be sure your text won't be interpreted as markdown
     :param txt: bare text to escape.
     """
-    txt = txt.replace('{', '\{')
-    txt = txt.replace('}', '\}')
-    return txt
+    return _md_escape_re.sub(_md_escape_trans, txt)

--- a/errbot/rendering/__init__.py
+++ b/errbot/rendering/__init__.py
@@ -6,14 +6,10 @@ from markdown.extensions.extra import ExtraExtension
 from markdown.extensions.attr_list import AttrListTreeprocessor
 
 ATTR_RE = re.compile(AttrListTreeprocessor.BASE_RE)
+MD_ESCAPE_RE = re.compile('|'.join(re.escape(c) for c in Markdown.ESCAPED_CHARS))
+
 # Here are few helpers to simplify the conversion from markdown to various
 # backend formats.
-
-_md_escape_re = re.compile('|'.join(re.escape(c) for c in Markdown.ESCAPED_CHARS))
-
-
-def _md_escape_trans(match):
-    return '\\' + match.group(0)
 
 
 def ansi():
@@ -92,4 +88,4 @@ def md_escape(txt):
     """ Call this if you want to be sure your text won't be interpreted as markdown
     :param txt: bare text to escape.
     """
-    return _md_escape_re.sub(_md_escape_trans, txt)
+    return MD_ESCAPE_RE.sub(lambda match: '\\' + match.group(0), txt)

--- a/tests/md_rendering_test.py
+++ b/tests/md_rendering_test.py
@@ -1,7 +1,7 @@
 # vim: ts=4:sw=4
 import logging
 import unittest
-from errbot.rendering import ansi, text, md
+from errbot.rendering import ansi, text, md, md_escape
 
 log = logging.getLogger(__name__)
 
@@ -20,3 +20,9 @@ class MdRendering(unittest.TestCase):
         mdc = md()
         self.assertEquals(mdc.convert("woot"), "woot")
         self.assertEquals(mdc.convert("woot{stuff} really{otherstuff}"), "woot really")
+
+    def test_escaping(self):
+        mdc = text()
+        original = '#not a title\n*not italic*\n`not code`\ntoto{not annotation}'
+        escaped = md_escape(original)
+        self.assertEquals(original, mdc.convert(escaped))


### PR DESCRIPTION
It should now preserve the original text from markdown transformations.