### PR TITLE
Fixes #439 - Slack: inconsistency in BOT_ADMINS.

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -496,6 +496,8 @@ class SlackBackend(ErrBot):
                                 "should be #channelname/username or @username : '%s'" % txtrep)
             channelname, username = plainrep.split('/')
         else:
+            username = txtrep
+        if not username or not len(username):
             raise Exception("Unparseable slack identifier, " +
                             "should be #channelname/username or @username : '%s'" % txtrep)
 


### PR DESCRIPTION
When using Slack as Backend, allowed administrators username
are now @username, username or #channel/username.