### PR TITLE
Slack fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ bugs:
 - Fixed various bugs with the ``@arg_botcmd`` decorator (`#516 <https://github.com/gbin/err/pull/516>`_)
 - Fixed warn_admins() on Telegram
 - Slack ACLs now properly check against usernames starting with `@`
+- Slack identifiers can now be built from a bare `#channel` string (without a username part)
+- Slack identifiers can now be built from a `<#C12345>` or `<@username>` string (the webclient formats them like this automatically when chatting with the bot)
 
 other:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ bugs:
 
 - Fixed various bugs with the ``@arg_botcmd`` decorator (`#516 <https://github.com/gbin/err/pull/516>`_)
 - Fixed warn_admins() on Telegram
+- Slack ACLs now properly check against usernames starting with `@`
 
 other:
 

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -130,7 +130,9 @@ class SlackIdentifier(DeprecationBridgeIdentifier):
     # Override for ACLs
     @property
     def aclattr(self):
-        return self.username.split('@')[0]
+        # Note: Don't use str(self) here because that will return
+        # an incorrect format from SlackMUCOccupant.
+        return "@%s" % self.username
 
     @property
     def fullname(self):

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -76,15 +76,18 @@ class SlackAPIResponseError(RuntimeError):
         super().__init__(*args, **kwargs)
 
 
+# TODO(gbin): remove this deprecation warnings at one point.
 class SlackIdentifier(DeprecationBridgeIdentifier):
-    # TODO(gbin): remove this deprecation warnings at one point.
+    """
+    This class describes a person on Slack's network.
+    """
 
     def __init__(self, sc, userid=None, channelid=None):
         if userid is not None and userid[0] not in ('U', 'B'):
-            raise Exception('This is not a Slack user or bot id: %s' % userid)
+            raise Exception('This is not a Slack user or bot id: %s (should start with U or B)' % userid)
 
         if channelid is not None and channelid[0] not in ('D', 'C', 'G'):
-            raise Exception('This is not a valid Slack channelid: %s' % channelid)
+            raise Exception('This is not a valid Slack channelid: %s (should start with D, C or G)' % channelid)
 
         self._userid = userid
         self._channelid = channelid

--- a/errbot/core_plugins/acls.py
+++ b/errbot/core_plugins/acls.py
@@ -29,10 +29,12 @@ class ACLS(BotPlugin):
 
         Return None, None, None if the command is blocked or deferred
         """
-        self.log.info("Check %s for ACLs." % cmd)
+        self.log.debug("Check %s for ACLs." % cmd)
 
         usr = get_acl_usr(msg)
         typ = msg.type
+
+        self.log.debug("Matching ACLs against username %s" % usr)
 
         if cmd not in self.bot_config.ACCESS_CONTROLS:
             self.bot_config.ACCESS_CONTROLS[cmd] = self.bot_config.ACCESS_CONTROLS_DEFAULT

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -127,9 +127,10 @@ class ErrBot(Backend, BotPluginManager):
             :param groupchat_nick_reply:
                 authorized the prefixing with the nick form the user
         """
-        s = compat_str(user)
-        if s is not None:
-            user = self.build_identifier(s)
+        if not hasattr(user, 'person'):
+            s = compat_str(user)
+            if s is not None:
+                user = self.build_identifier(s)
 
         mess = self.build_message(text)
         mess.to = user

--- a/tests/backend_tests/slack_tests.py
+++ b/tests/backend_tests/slack_tests.py
@@ -105,3 +105,61 @@ class SlackTests(unittest.TestCase):
         assert parts[0].endswith('```')
         assert parts[1].count('```') == 2
         assert parts[1].endswith('```\n')
+
+    def test_extract_identifiers(self):
+        extract_from = self.slack.extract_identifiers_from_string
+
+        self.assertEqual(
+            extract_from("<@U12345>"),
+            (None, "U12345", None, None)
+        )
+
+        self.assertEqual(
+            extract_from("<@B12345>"),
+            (None, "B12345", None, None)
+        )
+
+        self.assertEqual(
+            extract_from("<#C12345>"),
+            (None, None, None, "C12345")
+        )
+
+        self.assertEqual(
+            extract_from("<#G12345>"),
+            (None, None, None, "G12345")
+        )
+
+        self.assertEqual(
+            extract_from("<#D12345>"),
+            (None, None, None, "D12345")
+        )
+
+        self.assertEqual(
+            extract_from("@person"),
+            ("person", None, None, None)
+        )
+
+        self.assertEqual(
+            extract_from("#general/someuser"),
+            ("someuser", None, "general", None)
+        )
+
+        self.assertEqual(
+            extract_from("#general"),
+            (None, None, "general", None)
+        )
+
+        with self.assertRaises(ValueError):
+            extract_from("")
+
+        with self.assertRaises(ValueError):
+            extract_from("general")
+
+        with self.assertRaises(ValueError):
+            extract_from("<>")
+
+        with self.assertRaises(ValueError):
+            extract_from("<C12345>")
+
+        with self.assertRaises(ValueError):
+            extract_from("<@I12345>")


### PR DESCRIPTION
Quoting from `CHANGES.rst`:

- Slack ACLs now properly check against usernames starting with `@`
- Slack identifiers can now be built from a bare `#channel` string (without a username part)
- Slack identifiers can now be built from a `<#C12345>` or `<@U12345>` string (the webclient formats them like this automatically when chatting with the bot)

Fixes #477 
Fixes #439 
Fixes #533
Closes #528