### PR TITLE
Documentation fixes, mostly for pop & push_message

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -14,12 +14,12 @@ as soon as we can! Depending on our thoughts, we might decide to merge it in
 right away, or we may ask you to change certain parts before we will accept the
 change.
 
-In order to make the process as easy for everyone involved, please follow
+In order to make the process easy for everyone involved, please follow
 these guidelines as you open a pull request.
 
-* Make your changes on a seperate branch_, preferably giving it a descriptive name.
+* Make your changes on a separate branch_, preferably giving it a descriptive name.
 * Split your work up into smaller commits if possible, while making sure each commit
-  can still function on it's own. Do not commit work-in-progress code, commit it
+  can still function on its own. Do not commit work-in-progress code - commit it
   once it's working.
 * Run the test-suite before opening your pull request, and make sure all tests pass.
   You can run the tests with :command:`python run_tests.py` in the root of the
@@ -43,7 +43,7 @@ website, you can build the HTML locally as follows::
     make html
     # Then, open the generated _build/html/index.html in a browser
 
-To submit your changes back to us, please make your change in a seperate branch as
+To submit your changes back to us, please make your change in a separate branch as
 described in the previous section, then open a pull request with us.
 
 .. note::

--- a/docs/user_guide/plugin_development/testing.rst
+++ b/docs/user_guide/plugin_development/testing.rst
@@ -38,21 +38,21 @@ Our test, *test_myplugin.py*:
 .. code-block:: python
 
     import os
-    from errbot.backends.test import testbot, push_message, pop_message
+    from errbot.backends.test import testbot
 
 
     class TestMyPlugin(object):
         extra_plugin_dir = '.'
 
         def test_command(self, testbot):
-            push_message('!mycommand')
-            assert 'This is my awesome command' in pop_message()
+            testbot.push_message('!mycommand')
+            assert 'This is my awesome command' in testbot.pop_message()
 
-Lets walk through this line for line. First of all, we import :class:`~errbot.backends.test.testbot`, :func:`~errbot.backends.test.push_message` and :func:`~errbot.backends.test.pop_message` from the backends tests, there allow us to spin up a bot for testing purposes and interact with the message queue.
+Lets walk through this line for line. First of all, we import :class:`~errbot.backends.test.testbot` from the backends tests, to allow us to spin up a bot for testing purposes and interact with the message queue.
 
 Then we define our own test class and inside of it we set `extra_plugin_dir` to `.`, the current directory so that the test bot will pick up on your plugin.
 
-After that we define our first `test_` method which simply sends a command to the bot using :func:`~errbot.backends.test.push_message` and then asserts that the response we expect, *"This is my awesome command"* is in the message we receive from the bot which we get by calling :func:`~errbot.backends.test.pop_message`.
+After that we define our first `test_` method which simply sends a command to the bot using :func:`~errbot.backends.test.TestBot.push_message` and then asserts that the response we expect, *"This is my awesome command"* is in the message we receive from the bot which we get by calling :func:`~errbot.backends.test.TestBot.pop_message`.
 
 Helper methods
 --------------
@@ -176,19 +176,19 @@ All together now
     import os
     import unittest
     import myplugin
-    from errbot.backends.test import testbot, push_message, pop_message
+    from errbot.backends.test import testbot
     from errbot import plugin_manager
 
     class TestMyPluginBot(object):
         extra_plugin_dir = '.'
 
         def test_mycommand(self, testbot):
-            push_message('!mycommand')
-            assert 'This is my awesome command' in pop_message()
+            testbot.push_message('!mycommand')
+            assert 'This is my awesome command' in testbot.pop_message()
 
         def test_mycommand_another(self, testbot):
-            push_message('!mycommand another')
-            assert 'This is another awesome command' in pop_message()
+            testbot.push_message('!mycommand another')
+            assert 'This is another awesome command' in testbot.pop_message()
 
 
     class TestMyPluginStaticMethods(object):
@@ -215,7 +215,7 @@ PEP-8 and code coverage
 
 If you feel like it you can also add syntax checkers like `pep8` into the mix to validate your code behaves to certain stylistic best practices set out in PEP-8.
 
-First, install the pep8 for py.test_: :command:`pip instal pytest-pep8`.
+First, install the pep8 for py.test_: :command:`pip install pytest-pep8`.
 
 Then, simply add `--pep8` to the test invocation command: `py.test --pep8`.
 
@@ -246,7 +246,7 @@ In order to do that you'll need a `.travis.yml` similar to this:
       - 3.3
       - 3.4
     install:
-      - pip instal -q err pytest pytest-pep8 --use-wheel
+      - pip install -q err pytest pytest-pep8 --use-wheel
       - pip install -q coverage coveralls --use-wheel
     script:
       - coverage run --source myplugin -m py.test --pep8

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -340,12 +340,12 @@ class FullStackTest(unittest.TestCase, TestBot):
     For example, if you wanted to test the builtin `!about` command,
     you could write a test file with the following::
 
-        from errbot.backends.test import FullStackTest, push_message, pop_message
+        from errbot.backends.test import FullStackTest
 
         class TestCommands(FullStackTest):
             def test_about(self):
-                push_message('!about')
-                self.assertIn('Err version', pop_message())
+                self.push_message('!about')
+                self.assertIn('Err version', self.pop_message())
     """
 
     def setUp(self, extra_plugin_dir=None, extra_test_file=None, loglevel=logging.DEBUG):
@@ -376,7 +376,7 @@ def testbot(request):
     For example, if you wanted to test the builtin `!about` command,
     you could write a test file with the following::
 
-        from errbot.backends.test import testbot, push_message, pop_message
+        from errbot.backends.test import testbot
 
         def test_about(testbot):
             testbot.push_message('!about')
@@ -386,7 +386,7 @@ def testbot(request):
     by setting variables at module level or as class attributes (the
     latter taking precedence over the former). For example::
 
-        from errbot.backends.test import testbot, push_message, pop_message
+        from errbot.backends.test import testbot
 
         extra_plugin_dir = '/foo/bar'
 
@@ -396,7 +396,7 @@ def testbot(request):
 
     ..or::
 
-        from errbot.backends.test import testbot, push_message, pop_message
+        from errbot.backends.test import testbot
 
         extra_plugin_dir = '/foo/bar'
 


### PR DESCRIPTION
Now these are methods on testbot they no longer need to be imported.

Updated the testing documentation in all the places I noticed it was wrong.

(Also couldn't help fixing a couple of typos on the 'contributing.html' page whilst I was reading it :P )

I'm not 100% sure I corrected the FullStackTest docs in test.py correctly - would be grateful if someone could double-check.

Cheers :)

@zoni thanks for the encouragement & offer of help with this!

btw I tried running the tests locally but one failed - utils_tests.test_storage - it fails for me on master too though.. any ideas? (I posted this failure on gitter too)